### PR TITLE
Update README file following removal of "gmaps.init()".

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,6 @@ Let's plot a heatmap (data taken from the `Google maps API documentation <https:
 ::
 
     In [1]: import gmaps
-            gmaps.init()
 
     In [2]: data = [ [ 37.782, -122.447 ], # [ latitude, longitude ] pairs
                      [ 37.782, -122.445 ],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ Let's plot a heatmap (data taken from the `Google maps API documentation <https:
 .. code:: python
 
     In [1]: import gmaps
-            gmaps.init()
 
     In [2]: data = [ [ 37.782, -122.447 ], # [ latitude, longitude ] pairs
                      [ 37.782, -122.445 ],


### PR DESCRIPTION
The README file (and the long description in the setup script) still referred to gmaps.init. Now removed.
