### PR TITLE
Removed non-jQuery selector from heatmap_view.

### DIFF
--- a/gmaps/js/heatmap_view.js
+++ b/gmaps/js/heatmap_view.js
@@ -10,8 +10,6 @@ var HeatmapView = IPython.DOMWidgetView.extend({
 
     render : function() {
 
-        this.$el.addClass("map-container") ;
-
         this.$el.css("height", this.model.get("height")) ;
         this.$el.css("width", this.model.get("width")) ;
 
@@ -22,8 +20,7 @@ var HeatmapView = IPython.DOMWidgetView.extend({
             var bounds = that._getBounds() ;
 
             that.map =  new google.maps.Map(
-                document.getElementsByClassName('map-container')[0],
-                                 { center : bounds.getCenter()  }) ;
+                that.$el[0], { center : bounds.getCenter()  }) ;
 
             that.map.fitBounds(bounds) ;
 


### PR DESCRIPTION
The div element containing the map is just identified by "this.$el", which is more portable. It also means that we are only using jQuery selectors, which are much nicer than the getElementByClass / getElementById functions.

Fixes #2.
