### PR TITLE
Added information about examples in README file.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,11 @@ Getting started
 Currently, only heatmaps are supported. Draw a heatmap by passing a list of (latitude, longitude)
 pairs to the heatmap command.
 
+There are example notebooks in the examples directory. The heatmap example is
+also visible `on nbviewer
+<http://nbviewer.ipython.org/github/pbugnion/gmaps/blob/master/examples/ipy3/heatmap_demo.ipynb>`_,
+but note that you need to download the notebook to actually see the Google Map.
+
 Issue reporting and contributing
 --------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,11 @@ Getting started
 Currently, only heatmaps are supported. Draw a heatmap by passing a list of (latitude, longitude)
 pairs to the heatmap command.
 
+There are example notebooks in the examples directory. The heatmap example is
+also visible `on nbviewer
+<http://nbviewer.ipython.org/github/pbugnion/gmaps/blob/master/examples/ipy3/heatmap_demo.ipynb>`_,
+but note that you need to download the notebook to actually see the Google Map.
+
 Issue reporting and contributing
 --------------------------------
 


### PR DESCRIPTION
README / setup files now point reader to the heatmap example notebook on
nbviewer. It's not perfect, but it's the start of a more in-depth
documentation effort.
