### PR TITLE
Allow injecting API keys

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2,6 +2,8 @@
 API documentation
 =================
 
+.. autofunction:: gmaps.configure
+
 .. autoclass:: gmaps.Map
 
 .. autoclass:: gmaps.Heatmap

--- a/docs/source/gmaps.rst
+++ b/docs/source/gmaps.rst
@@ -60,6 +60,27 @@ and::
 
 The former construction is useful for modifying a map once it has been built. Any change in parameters will propagate to maps in which those layers are included.
 
+Authentication
+^^^^^^^^^^^^^^
+
+Some operations on Google Maps require that you tell Google who you are. To authenticate with Google Maps, follow the `instructions <https://console.developers.google.com/flows/enableapi?apiid=maps_backend,geocoding_backend,directions_backend,distance_matrix_backend,elevation_backend&keyType=CLIENT_SIDE&reusekey=true>`_ for creating an API key. You will probably want to create a new project, then click on the `Credentials` section and create a `Browser key`. The API key is a string that starts with the letters ``AI``.
+
+You can pass this key to `gmaps` with the ``configure`` method::
+
+  gmaps.configure(api_key="AI...")
+
+Maps and layers created after the call to ``gmaps.configure`` will have access to the API key.
+
+Avoid hard-coding the API key into your Jupyter notebooks. You can do this with `environment variables <https://en.wikipedia.org/wiki/Environment_variable>`_. Add the following line to your shell start-up file (probably `~/.profile`)::
+
+  export GOOGLE_API_KEY=AI...
+
+Make sure you don't put spaces around the ``=`` sign. If you then open a new terminal window and type ``env``, you should see that your API key. Start a new Jupyter notebook server in a new terminal, and type::
+
+  import os
+  import gmaps
+
+  gmaps.configure(api_key=os.environ["GOOGLE_API_KEY"))
 
 Heatmaps
 ^^^^^^^^

--- a/gmaps/maps.py
+++ b/gmaps/maps.py
@@ -4,12 +4,29 @@ import warnings
 import ipywidgets as widgets
 from traitlets import (Unicode, CUnicode, default, Int,
                        List, Tuple, Float, Instance, validate,
-                       observe)
+                       observe, Enum, Dict, HasTraits)
 
 import gmaps.geotraitlets as geotraitlets
 
 DEFAULT_CENTER = (46.2, 6.1)
 DEFAULT_BOUNDS = [(46.2, 6.1), (47.2, 7.1)]
+
+_default_configuration = {"api_key": None}
+
+def configure(api_key=None):
+    configuration = {"api_key": api_key}
+    global _default_configuration
+    _default_configuration = configuration
+
+
+class ConfigurationMixin(HasTraits):
+    configuration = Dict(
+        traits={"api_key": Unicode(allow_none=True)}).tag(sync=True)
+
+    @default("configuration")
+    def _config_default(self):
+        return _default_configuration
+
 
 class InvalidPointException(Exception):
     pass
@@ -17,7 +34,8 @@ class InvalidPointException(Exception):
 class DirectionsServiceException(RuntimeError):
     pass
 
-class Map(widgets.DOMWidget):
+
+class Map(widgets.DOMWidget, ConfigurationMixin):
     """
     Base map class
 

--- a/gmaps/maps.py
+++ b/gmaps/maps.py
@@ -14,6 +14,12 @@ DEFAULT_BOUNDS = [(46.2, 6.1), (47.2, 7.1)]
 _default_configuration = {"api_key": None}
 
 def configure(api_key=None):
+    """
+    Configure access to the GoogleMaps API.
+
+    :param api_key: String denoting the key to use when accessing Google maps, or
+        None to not pass an API key.
+    """
     configuration = {"api_key": api_key}
     global _default_configuration
     _default_configuration = configuration

--- a/gmaps/maps.py
+++ b/gmaps/maps.py
@@ -37,7 +37,7 @@ class Map(widgets.DOMWidget):
     data_bounds = List(DEFAULT_BOUNDS).tag(sync=True)
 
     def add_layer(self, layer):
-        self.layers = tuple([layer for layer in self.layers] + [layer])
+        self.layers = tuple([l for l in self.layers] + [layer])
 
     @default("layout")
     def _default_layout(self):

--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -2,7 +2,17 @@ var widgets = require('jupyter-js-widgets');
 var _ = require('underscore');
 
 var GoogleMapsLoader = require('google-maps');
-GoogleMapsLoader.LIBRARIES = ["visualization"] ;
+
+function reloadGoogleMaps(configuration) {
+    GoogleMapsLoader.release();
+    GoogleMapsLoader.LIBRARIES = ["visualization"] ;
+    if (configuration["api_key"] !== null &&
+        configuration["api_key"] !== undefined) {
+            GoogleMapsLoader.KEY = configuration["api_key"];
+    };
+}
+
+reloadGoogleMaps({}) ;
 
 function gPointToList(gpoint) {
     return [gpoint.lat(), gpoint.lng()];
@@ -14,6 +24,15 @@ function gBoundsToList(gbounds) {
     return [sw, ne]
 }
 
+// Mixins
+
+var ConfigurationMixin = {
+    load_configuration: function() {
+        var model_configuration = this.model.get("configuration");
+        reloadGoogleMaps(model_configuration);
+    }
+} ;
+
 
 // Views
 
@@ -21,7 +40,7 @@ var GMapsLayerView = widgets.WidgetView.extend({
     initialize: function(parameters) {
         GMapsLayerView.__super__.initialize.apply(this, arguments);
         this.map_view = this.options.map_view ;
-    }
+    },
 });
 
 
@@ -42,16 +61,15 @@ var DirectionsLayerView = GMapsLayerView.extend({
             origin: orig,
             destination: dest,
             waypoints: wps,
-            travelMode: google.maps.DirectionsTravelMode.DRIVING
         };
 
         var directionsService = new google.maps.DirectionsService();
 
         directionsService.route(request, function(response, status) {
-            // print to the browser console (mostly for debugging) 
-            console.log("Direction service returned: ", status) ; 
+            // print to the browser console (mostly for debugging)
+            console.log("Direction service returned: ", status) ;
             // set a flag in the model
-            that.model.set("layer_status", status) ; 
+            that.model.set("layer_status", status) ;
             that.touch() ; // push `layer_status` changes to the model
             if (status == google.maps.DirectionsStatus.OK) {
                 that.response = that.directionsDisplay ;
@@ -69,7 +87,7 @@ var DirectionsLayerView = GMapsLayerView.extend({
     },
 
     get_dest: function(model_data) {
-        var last_point = _.last(model_data); 
+        var last_point = _.last(model_data);
         return new google.maps.LatLng(last_point[0], last_point[1]);
     },
 
@@ -82,8 +100,8 @@ var DirectionsLayerView = GMapsLayerView.extend({
         });
         return data_as_google;
     }
-
 });
+
 
 var HeatmapLayerBaseView = GMapsLayerView.extend({
     render: function() {
@@ -151,6 +169,7 @@ var WeightedHeatmapLayerView = HeatmapLayerBaseView.extend({
 
 var PlainmapView = widgets.DOMWidgetView.extend({
     render: function() {
+        this.load_configuration();
         this.el.style["width"] = this.model.get("width");
         this.el.style["height"] = this.model.get("height");
 
@@ -161,7 +180,7 @@ var PlainmapView = widgets.DOMWidgetView.extend({
 
         var that = this ;
         this.on("displayed", function() {
-            GoogleMapsLoader.load(function(google) {
+            GoogleMapsLoader.load(function (google) {
                 that.map = new google.maps.Map(that.el) ;
                 that.update_bounds(initial_bounds);
 
@@ -171,7 +190,7 @@ var PlainmapView = widgets.DOMWidgetView.extend({
                 window.setTimeout(function() {
                     google.maps.event.trigger(that.map, 'resize') ;
                 }, 1000);
-            }) ;
+            });
         });
     },
 
@@ -197,9 +216,11 @@ var PlainmapView = widgets.DOMWidgetView.extend({
             child_view.add_to_map_view(that) ;
             return child_view;
         })
-    }
+    },
 
 });
+
+_.extend(PlainmapView.prototype, ConfigurationMixin);
 
 
 // Models
@@ -262,5 +283,5 @@ module.exports = {
     PlainmapModel: PlainmapModel,
     DirectionsLayerModel: DirectionsLayerModel,
     SimpleHeatmapLayerModel: SimpleHeatmapLayerModel,
-    WeightedHeatmapLayerModel: WeightedHeatmapLayerModel
+    WeightedHeatmapLayerModel: WeightedHeatmapLayerModel,
 };

--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -61,6 +61,7 @@ var DirectionsLayerView = GMapsLayerView.extend({
             origin: orig,
             destination: dest,
             waypoints: wps,
+            travelMode: google.maps.TravelMode.DRIVING
         };
 
         var directionsService = new google.maps.DirectionsService();


### PR DESCRIPTION
This PR allows injection of a Google Maps API key. This increases the number of requests that a user can make, and may even be necessary for some services. This addresses issue #61 .

The interface is:

```python

import gmaps

gmaps.configure(api_key="your-api-key")

m = gmaps.Map()
d = gmaps.Directions(data=[[45.0, 5.0], [46.0, 7.0], [47.0, 6.0]])

m.add_layer(d)
m
```

To unset the API key, use:

```python
gmaps.configure(api_key=None)
```

The configuration can be applied at any time, but any existing widgets will have to be reloaded (by re-executing the cell in which they are rendered) for the configuration changes to affect that widget.