### PR TITLE
Improve JS code layout

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -19,6 +19,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
+    "babel-cli": "^6.11.4",
+    "babel-core": "^6.11.4",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.9.0",
     "json-loader": "^0.5.4",
     "webpack": "^1.12.14"
   },

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -4,6 +4,7 @@ var version = require('./package.json').version;
 // stored in a separate local variable.
 var loaders = [
     { test: /\.json$/, loader: 'json-loader' },
+    { test: /\.js$/, loader: 'babel', query: {presets: ['es2015']}, exclude: /node_modules/ }
 ];
 
 


### PR DESCRIPTION
This PR migrates the JavaScript to [ECMAScript 2015](https://babeljs.io/docs/learn-es2015/ and tidies the layout of the JS code. I have tried to stick to the [Airbnb style / best practice] guide(https://github.com/airbnb/javascript).

There should be no changes in browser compatibility, since the JS code is transpiled and bundled using Webpack anyway.