### PR TITLE
Calculate bounds of data layer in heatmap correctly

### DIFF
--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -163,6 +163,11 @@ export const WeightedHeatmapLayerView = HeatmapLayerBaseView.extend({
     }
 })
 
+export const MarkerLayerView = GMapsLayerView.extend({
+    render() {
+
+    }
+})
 
 export const PlainmapView = widgets.DOMWidgetView.extend({
     render() {
@@ -185,6 +190,7 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
                 // hack to force the map to redraw
                 setTimeout(() => {
                     google.maps.event.trigger(this.map, 'resize') ;
+                    this.updateBounds(initialBounds);
                 }, 1000);
             })
         })

--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -191,7 +191,7 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
                 setTimeout(() => {
                     google.maps.event.trigger(this.map, 'resize') ;
                     this.updateBounds(initialBounds);
-                }, 1000);
+                }, 500);
             })
         })
     },


### PR DESCRIPTION
Prior to this PR, the bounds of a heatmap for which the data spanned the -180 degrees / +180 degrees line were calculated incorrectly. The bounds were calculated as:

 - the most eastern latitude in the data is `min(latitudes)`
 - the most western latitude is `max(latitudes)`

This doesn't work if the most eastern latitude is, e.g., 150 and the most western is -30. The map would then go from -30 all the way round to 150. This was evident in the earthquakes dataset:

<img width="853" alt="screen shot 2016-09-07 at 07 27 31" src="https://cloud.githubusercontent.com/assets/1392879/18301904/9d587246-74cc-11e6-8417-62eaa1d9b424.png">

Now, the bounds are calculated by assuming the data is distributed with a  [wrapped normal distribution](https://en.wikipedia.org/wiki/Wrapped_normal_distribution). We then take the latitude bounds as 2 * distribution's standard deviation (or 360 degrees, whichever is smaller). This results in much better bounds:

<img width="842" alt="screen shot 2016-09-07 at 07 30 16" src="https://cloud.githubusercontent.com/assets/1392879/18301963/f708ead2-74cc-11e6-92a4-5da2b4437848.png">
