### PR TITLE
Feature: Add InfoBox Feature to Marker 

### DIFF
--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -18,6 +18,7 @@ class _BaseMarkerMixin(HasTraits):
     _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     location = geotraitlets.Point(DEFAULT_CENTER).tag(sync=True)
     hover_text = Unicode("").tag(sync=True)
+    info_html = Unicode("").tag(sync=True)
 
 
 class Symbol(_BaseMarkerMixin, widgets.Widget):
@@ -135,10 +136,12 @@ def _merge_option_dicts(option_dicts):
 
 def _symbol_layer_options(
         locations, hover_text, fill_color, fill_opacity,
-        stroke_color, stroke_opacity, scale):
+        stroke_color, stroke_opacity, scale,info_html):
     number_markers = len(locations)
     if _is_atomic(hover_text):
         hover_text = [hover_text] * number_markers
+    if _is_atomic(info_html):
+        info_html = [info_html] * number_markers
     if _is_atomic(scale):
         scale = [scale] * number_markers
     if _is_color_atomic(fill_color):
@@ -152,6 +155,7 @@ def _symbol_layer_options(
     options = {
         "location": locations,
         "hover_text": hover_text,
+        "info_html": info_html,
         "fill_color": fill_color,
         "stroke_color": stroke_color,
         "scale": scale,
@@ -161,22 +165,25 @@ def _symbol_layer_options(
     return _merge_option_dicts(options)
 
 
-def _marker_layer_options(locations, hover_text, label):
+def _marker_layer_options(locations, hover_text, label,info_html):
     number_markers = len(locations)
     if _is_atomic(hover_text):
         hover_text = [hover_text] * number_markers
+    if _is_atomic(info_html):
+        info_html = [info_html] * number_markers
     if _is_atomic(label):
         label = [label] * number_markers
     options = {
         "location": locations,
         "hover_text": hover_text,
+        "info_html": info_html,
         "label": label
     }
     return _merge_option_dicts(options)
 
 
 def symbol_layer(
-        locations, hover_text="", fill_color=None, fill_opacity=1.0,
+        locations, hover_text="", info_html='',fill_color=None, fill_opacity=1.0,
         stroke_color=None, stroke_opacity=1.0, scale=3):
     """
     Symbol layer
@@ -282,12 +289,12 @@ def symbol_layer(
     """
     options = _symbol_layer_options(
         locations, hover_text, fill_color,
-        fill_opacity, stroke_color, stroke_opacity, scale)
+        fill_opacity, stroke_color, stroke_opacity, scale,info_html)
     symbols = [Symbol(**option) for option in options]
     return Markers(markers=symbols)
 
 
-def marker_layer(locations, hover_text="", label=""):
+def marker_layer(locations, hover_text="",into_html="", label=""):
     """
     Marker layer
 
@@ -338,6 +345,6 @@ def marker_layer(locations, hover_text="", label=""):
     :type label: string or list of strings, optional
     """
     marker_options = _marker_layer_options(
-        locations, hover_text, label)
+        locations, hover_text, label,info_html)
     markers = [Marker(**option) for option in marker_options]
     return Markers(markers=markers)

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -11,16 +11,28 @@ class MarkerLayer(unittest.TestCase):
 
     def test_hover_text_atomic(self):
         marker_options = _marker_layer_options(
-            self.locations, hover_text="test-text", label="")
+            self.locations, hover_text="test-text", label="",info_html="")
         for options in marker_options:
             assert options["hover_text"] == "test-text"
 
     def test_hover_text_lists(self):
         marker_options = _marker_layer_options(
-            self.locations, hover_text=["t1", "t2"], label="")
+            self.locations, hover_text=["t1", "t2"], label="",info_html="")
         hover_texts = [options["hover_text"] for options in marker_options]
         assert tuple(hover_texts) == ("t1", "t2")
 
+    def test_infobox_text_atomic(self):
+        marker_options = _marker_layer_options(
+            self.locations, info_html="<h3>test-html-infobox</h3>", label="",hover_text="")
+        for options in marker_options:
+            assert options["info_html"] == "<h3>test-html-infobox</h3>"
+
+
+    def test_infobox_text_lists(self):
+        marker_options = _marker_layer_options(
+            self.locations, info_html=["<h1>h1</h1>", "<h2>h2</h2>"], label="",hover_text="")
+        infos_html = [options["info_html"] for options in marker_options]
+        assert tuple(infos_html) == ("<h1>h1</h1>", "<h2>h2</h2>")
 
 class SymbolLayer(unittest.TestCase):
 
@@ -28,7 +40,7 @@ class SymbolLayer(unittest.TestCase):
         self.locations = [(-5.0, 5.0), (10.0, 10.0)]
         self.kwargs = {
             "hover_text": "", "fill_color": "red", "scale": 5,
-            "fill_opacity": 1.0, "stroke_opacity": 1.0
+            "fill_opacity": 1.0, "stroke_opacity": 1.0,"info_html":""
         }
 
     def test_stroke_color_atomic_text(self):

--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -175,6 +175,7 @@ export const BaseMarkerView = widgets.WidgetView.extend({
     render() {
         const [lat, lng] = this.model.get("location")
         const title = this.model.get("hover_text")
+        const infoBoxHtml = this.model.get("info_html")
         const styleOptions = this.getStyleOptions()
         const markerOptions = {
             position: {lat, lng},
@@ -183,17 +184,26 @@ export const BaseMarkerView = widgets.WidgetView.extend({
             ...styleOptions
         }
         this.marker = new google.maps.Marker(markerOptions)
+
+        this.infoWindow=new google.maps.InfoWindow({
+            content: infoBoxHtml
+        });
         this.modelEvents()
     },
 
     addToMapView(mapView) {
-        this.marker.setMap(mapView.map)
+        let marker= this.marker;
+        let infoWindow=this.infoWindow;
+        marker.setMap(mapView.map);
+        marker.addListener('click', function() {
+            infoWindow.open(mapView.map, marker);
+        });
     },
 
     modelEvents() {
         // Simple properties:
         const properties = [
-            ['title', 'hover_text']
+            ['title', 'hover_text','info_html']
         ]
         properties.forEach(([nameInView, nameInModel]) => {
             const callback = (


### PR DESCRIPTION
Example:

```python
m = gmaps.Map()
locations = [
              (-34.0, -59.166672),
              (-32.23333, -64.433327),
          ]
names = ["Atucha", "Embalse"]
infos_html=["<h1>Atucha</h1>","<h2>Embalse</h2>"]
symbol_layer = gmaps.symbol_layer(locations, hover_text=names,info_html=infos_html)
m = gmaps.Map()
m.add_layer(symbol_layer)
m
```
![captura de tela de 2016-12-10 16 08 50](https://cloud.githubusercontent.com/assets/6979335/21075194/0700ea5a-bef3-11e6-9594-9b91290ba114.png)
