### PR TITLE
Infobox empty fix

### DIFF
--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -137,6 +137,25 @@ def _merge_option_dicts(option_dicts):
     return option_lists
 
 
+def _info_box_option_lists(number_markers, info_box_content, display_info_box):
+    if _is_atomic(info_box_content):
+        info_box_content = [info_box_content] * number_markers
+    if _is_atomic(display_info_box):
+        display_info_box = [display_info_box] * number_markers
+
+    # Set value for display_info_box if it's still the default
+    for imarker in range(number_markers):
+        if display_info_box[imarker] is None:
+            is_content_empty = (info_box_content[imarker] is None)
+            display_info_box[imarker] = not is_content_empty
+
+    options = {
+        "info_box_content": info_box_content,
+        "display_info_box": display_info_box
+    }
+    return options
+
+
 def _symbol_layer_options(
         locations, hover_text, fill_color, fill_opacity,
         stroke_color, stroke_opacity, scale,
@@ -154,29 +173,21 @@ def _symbol_layer_options(
         stroke_opacity = [stroke_opacity] * number_markers
     if _is_atomic(fill_opacity):
         fill_opacity = [fill_opacity] * number_markers
-    if _is_atomic(info_box_content):
-        info_box_content = [info_box_content] * number_markers
-    if _is_atomic(display_info_box):
-        display_info_box = [display_info_box] * number_markers
 
-    # Set value for display_info_box if it's still the default
-    for imarker in range(number_markers):
-        if display_info_box[imarker] is None:
-            is_content_empty = (info_box_content[imarker] is None)
-            display_info_box[imarker] = not is_content_empty
-
-    options = {
+    symbol_options = {
         "location": locations,
         "hover_text": hover_text,
-        "info_box_content": info_box_content,
         "fill_color": fill_color,
         "stroke_color": stroke_color,
-        "scale": scale,
-        "stroke_opacity": stroke_opacity,
-        "fill_opacity": fill_opacity,
-        "display_info_box": display_info_box
+        "scale": scale
     }
-    return _merge_option_dicts(options)
+
+    info_box_options = _info_box_option_lists(
+        number_markers, info_box_content, display_info_box)
+
+    symbol_options.update(info_box_options)
+
+    return _merge_option_dicts(symbol_options)
 
 
 def _marker_layer_options(

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -199,23 +199,19 @@ def _marker_layer_options(
         label = [label] * number_markers
     if _is_atomic(info_box_content):
         info_box_content = [info_box_content] * number_markers
-    if _is_atomic(display_info_box):
-        display_info_box = [display_info_box] * number_markers
 
-    # Set value for display_info_box if it's still the default
-    for imarker in range(number_markers):
-        if display_info_box[imarker] is None:
-            is_content_empty = (info_box_content[imarker] is None)
-            display_info_box[imarker] = not is_content_empty
-
-    options = {
+    marker_options = {
         "location": locations,
         "hover_text": hover_text,
-        "label": label,
-        "info_box_content": info_box_content,
-        "display_info_box": display_info_box
+        "label": label
     }
-    return _merge_option_dicts(options)
+
+    info_box_options = _info_box_option_lists(
+        number_markers, info_box_content, display_info_box)
+
+    marker_options.update(info_box_options)
+
+    return _merge_option_dicts(marker_options)
 
 
 def symbol_layer(

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -186,9 +186,9 @@ def _marker_layer_options(locations, hover_text, label, info_box_content):
 
 
 def symbol_layer(
-        locations, hover_text="", info_box_content="", fill_color=None,
+        locations, hover_text="", fill_color=None,
         fill_opacity=1.0, stroke_color=None, stroke_opacity=1.0,
-        scale=3):
+        scale=3, info_box_content=""):
     """
     Symbol layer
 
@@ -262,13 +262,6 @@ def symbol_layer(
         the user's mouse hovers over a symbol.
     :type hover_text: string or list of strings, optional
 
-    :param info_box_content:
-        Content to be displayed when user clicks on a marker. This should
-        either be a single string, in which case the same content will apply to
-        every marker, or a list of strings of the same length of the
-        `locations` list.
-    :type info_box_content: string or list of strings, optional
-
     :param fill_color:
         The fill color of the symbol. This can be specified as a
         single color, in which case the same color will apply to every symbol,
@@ -307,6 +300,13 @@ def symbol_layer(
         or it must be an iterable of the same length as ``locations``.
         The scale must be greater than 1. This defaults to 3.
     :type scale: integer or list of integers, optional
+
+    :param info_box_content:
+        Content to be displayed when user clicks on a marker. This should
+        either be a single string, in which case the same content will apply to
+        every marker, or a list of strings of the same length of the
+        `locations` list.
+    :type info_box_content: string or list of strings, optional
     """
     options = _symbol_layer_options(
         locations, hover_text, fill_color,
@@ -315,7 +315,7 @@ def symbol_layer(
     return Markers(markers=symbols)
 
 
-def marker_layer(locations, hover_text="", info_box_content="", label=""):
+def marker_layer(locations, hover_text="", label="", info_box_content=""):
     """
     Marker layer
 
@@ -355,13 +355,6 @@ def marker_layer(locations, hover_text="", info_box_content="", label=""):
         the user's mouse hovers over a marker.
     :type hover_text: string or list of strings, optional
 
-    :param info_box_content:
-        Content to be displayed when user clicks on a marker. This should
-        either be a single string, in which case the same content will apply to
-        every marker, or a list of strings of the same length of the
-        `locations` list.
-    :type info_box_content: string or list of strings, optional
-
     :param label:
         Text to be displayed inside the marker. Google maps
         only displays the first letter of whatever string is
@@ -371,6 +364,13 @@ def marker_layer(locations, hover_text="", info_box_content="", label=""):
         strings, in which case it must be of the same length
         as `locations`.
     :type label: string or list of strings, optional
+
+    :param info_box_content:
+        Content to be displayed when user clicks on a marker. This should
+        either be a single string, in which case the same content will apply to
+        every marker, or a list of strings of the same length of the
+        `locations` list.
+    :type info_box_content: string or list of strings, optional
     """
     marker_options = _marker_layer_options(
         locations, hover_text, label, info_box_content)

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -177,11 +177,14 @@ def _marker_layer_options(
         info_box_content = [info_box_content] * number_markers
     if _is_atomic(label):
         label = [label] * number_markers
+    if _is_atomic(display_info_box):
+        display_info_box = [display_info_box] * number_markers
     options = {
         "location": locations,
         "hover_text": hover_text,
         "label": label,
-        "info_box_content": info_box_content
+        "info_box_content": info_box_content,
+        "display_info_box": display_info_box
     }
     return _merge_option_dicts(options)
 

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -169,7 +169,7 @@ def _symbol_layer_options(
 
 
 def _marker_layer_options(
-        locations, hover_text, label, info_box_content):
+        locations, hover_text, label, info_box_content, display_info_box):
     number_markers = len(locations)
     if _is_atomic(hover_text):
         hover_text = [hover_text] * number_markers
@@ -317,7 +317,9 @@ def symbol_layer(
     return Markers(markers=symbols)
 
 
-def marker_layer(locations, hover_text="", label="", info_box_content=""):
+def marker_layer(
+        locations, hover_text="", label="",
+        info_box_content="", display_info_box=None):
     """
     Marker layer
 
@@ -375,6 +377,6 @@ def marker_layer(locations, hover_text="", label="", info_box_content=""):
     :type info_box_content: string or list of strings, optional
     """
     marker_options = _marker_layer_options(
-        locations, hover_text, label, info_box_content)
+        locations, hover_text, label, info_box_content, display_info_box)
     markers = [Marker(**option) for option in marker_options]
     return Markers(markers=markers)

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -180,10 +180,11 @@ def _marker_layer_options(
     if _is_atomic(display_info_box):
         display_info_box = [display_info_box] * number_markers
 
-    # Set display_info_box to True if the content is set
+    # Set value for display_info_box if it's still the default
     for imarker in range(number_markers):
-        if display_info_box[imarker] is None and info_box_content[imarker]:
-            display_info_box[imarker] = True
+        if display_info_box[imarker] is None:
+            is_content_empty = (info_box_content[imarker] is None)
+            display_info_box[imarker] = not is_content_empty
 
     options = {
         "location": locations,
@@ -328,7 +329,7 @@ def symbol_layer(
 
 def marker_layer(
         locations, hover_text="", label="",
-        info_box_content="", display_info_box=None):
+        info_box_content=None, display_info_box=None):
     """
     Marker layer
 

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -20,7 +20,7 @@ class _BaseMarkerMixin(HasTraits):
     _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     location = geotraitlets.Point(DEFAULT_CENTER).tag(sync=True)
     hover_text = Unicode("").tag(sync=True)
-    show_info_box = Bool(False).tag(sync=True)
+    display_info_box = Bool(False).tag(sync=True)
     info_box_content = Unicode("").tag(sync=True)
 
 

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -147,7 +147,11 @@ def _info_box_option_lists(number_markers, info_box_content, display_info_box):
     for imarker in range(number_markers):
         if display_info_box[imarker] is None:
             is_content_empty = (info_box_content[imarker] is None)
-            display_info_box[imarker] = not is_content_empty
+            if is_content_empty:
+                display_info_box[imarker] = False
+                info_box_content[imarker] = ""
+            else:
+                display_info_box[imarker] = True
 
     options = {
         "info_box_content": info_box_content,
@@ -217,7 +221,7 @@ def _marker_layer_options(
 def symbol_layer(
         locations, hover_text="", fill_color=None,
         fill_opacity=1.0, stroke_color=None, stroke_opacity=1.0,
-        scale=3, info_box_content=""):
+        scale=3, info_box_content=None, display_info_box=None):
     """
     Symbol layer
 
@@ -349,7 +353,7 @@ def symbol_layer(
     options = _symbol_layer_options(
         locations, hover_text, fill_color,
         fill_opacity, stroke_color, stroke_opacity, scale,
-        info_box_content)
+        info_box_content, display_info_box)
     symbols = [Symbol(**option) for option in options]
     return Markers(markers=symbols)
 

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -168,7 +168,8 @@ def _symbol_layer_options(
     return _merge_option_dicts(options)
 
 
-def _marker_layer_options(locations, hover_text, label, info_box_content):
+def _marker_layer_options(
+        locations, hover_text, label, info_box_content):
     number_markers = len(locations)
     if _is_atomic(hover_text):
         hover_text = [hover_text] * number_markers
@@ -179,8 +180,8 @@ def _marker_layer_options(locations, hover_text, label, info_box_content):
     options = {
         "location": locations,
         "hover_text": hover_text,
-        "info_box_content": info_box_content,
-        "label": label
+        "label": label,
+        "info_box_content": info_box_content
     }
     return _merge_option_dicts(options)
 
@@ -310,7 +311,8 @@ def symbol_layer(
     """
     options = _symbol_layer_options(
         locations, hover_text, fill_color,
-        fill_opacity, stroke_color, stroke_opacity, scale, info_box_content)
+        fill_opacity, stroke_color, stroke_opacity, scale,
+        info_box_content)
     symbols = [Symbol(**option) for option in options]
     return Markers(markers=symbols)
 

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -329,6 +329,15 @@ def symbol_layer(
         every marker, or a list of strings of the same length of the
         `locations` list.
     :type info_box_content: string or list of strings, optional
+
+    :param display_info_box:
+        Whether to display an info box when the user clicks on a symbol.
+        This should either be a single boolean value, in which case it
+        will be applied to every symbol, or a list of boolean values of the
+        same length as the `locations` list.
+        The default value is True for any symbols for which `info_box_content`
+        is set, and False otherwise.
+    :type display_info_box: boolean or list of booleans, optional
     """
     options = _symbol_layer_options(
         locations, hover_text, fill_color,

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -173,12 +173,18 @@ def _marker_layer_options(
     number_markers = len(locations)
     if _is_atomic(hover_text):
         hover_text = [hover_text] * number_markers
-    if _is_atomic(info_box_content):
-        info_box_content = [info_box_content] * number_markers
     if _is_atomic(label):
         label = [label] * number_markers
+    if _is_atomic(info_box_content):
+        info_box_content = [info_box_content] * number_markers
     if _is_atomic(display_info_box):
         display_info_box = [display_info_box] * number_markers
+
+    # Set display_info_box to True if the content is set
+    for imarker in range(number_markers):
+        if display_info_box[imarker] is None and info_box_content[imarker]:
+            display_info_box[imarker] = True
+
     options = {
         "location": locations,
         "hover_text": hover_text,

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -184,8 +184,8 @@ def _marker_layer_options(locations, hover_text, label, info_box_content):
 
 def symbol_layer(
         locations, hover_text="", info_box_content="", fill_color=None,
-        fill_opacity=1.0,
-        stroke_color=None, stroke_opacity=1.0, scale=3):
+        fill_opacity=1.0, stroke_color=None, stroke_opacity=1.0,
+        scale=3):
     """
     Symbol layer
 

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -225,7 +225,7 @@ def symbol_layer(
     user clicks on a marker.
 
     >>> list_of_infoboxes = [
-            "Simple String info box",
+            "Simple string info box",
             "<a href='http://example.com'>HTML content</a>"
         ]
     >>> symbol_layer = gmaps.symbol_layer(
@@ -385,6 +385,15 @@ def marker_layer(
         every marker, or a list of strings of the same length of the
         `locations` list.
     :type info_box_content: string or list of strings, optional
+
+    :param display_info_box:
+        Whether to display an info box when the user clicks on a marker.
+        This should either be a single boolean value, in which case it
+        will be applied to every marker, or a list of boolean values of the
+        same length as the `locations` list.
+        The default value is True for any markers for which `info_box_content`
+        is set, and False otherwise.
+    :type display_info_box: boolean or list of booleans, optional
     """
     marker_options = _marker_layer_options(
         locations, hover_text, label, info_box_content, display_info_box)

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -3,7 +3,9 @@ import collections
 
 from six import string_types
 import ipywidgets as widgets
-from traitlets import Unicode, Int, List, observe, HasTraits, Float
+from traitlets import (
+    Unicode, Int, List, observe, HasTraits, Float, Bool
+)
 
 import gmaps.geotraitlets as geotraitlets
 import gmaps.bounds as bounds
@@ -18,6 +20,7 @@ class _BaseMarkerMixin(HasTraits):
     _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     location = geotraitlets.Point(DEFAULT_CENTER).tag(sync=True)
     hover_text = Unicode("").tag(sync=True)
+    show_info_box = Bool(False).tag(sync=True)
     info_box_content = Unicode("").tag(sync=True)
 
 

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -139,12 +139,11 @@ def _merge_option_dicts(option_dicts):
 
 def _symbol_layer_options(
         locations, hover_text, fill_color, fill_opacity,
-        stroke_color, stroke_opacity, scale, info_box_content):
+        stroke_color, stroke_opacity, scale,
+        info_box_content, display_info_box):
     number_markers = len(locations)
     if _is_atomic(hover_text):
         hover_text = [hover_text] * number_markers
-    if _is_atomic(info_box_content):
-        info_box_content = [info_box_content] * number_markers
     if _is_atomic(scale):
         scale = [scale] * number_markers
     if _is_color_atomic(fill_color):
@@ -155,6 +154,17 @@ def _symbol_layer_options(
         stroke_opacity = [stroke_opacity] * number_markers
     if _is_atomic(fill_opacity):
         fill_opacity = [fill_opacity] * number_markers
+    if _is_atomic(info_box_content):
+        info_box_content = [info_box_content] * number_markers
+    if _is_atomic(display_info_box):
+        display_info_box = [display_info_box] * number_markers
+
+    # Set value for display_info_box if it's still the default
+    for imarker in range(number_markers):
+        if display_info_box[imarker] is None:
+            is_content_empty = (info_box_content[imarker] is None)
+            display_info_box[imarker] = not is_content_empty
+
     options = {
         "location": locations,
         "hover_text": hover_text,
@@ -163,7 +173,8 @@ def _symbol_layer_options(
         "stroke_color": stroke_color,
         "scale": scale,
         "stroke_opacity": stroke_opacity,
-        "fill_opacity": fill_opacity
+        "fill_opacity": fill_opacity,
+        "display_info_box": display_info_box
     }
     return _merge_option_dicts(options)
 

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -8,35 +8,42 @@ class MarkerLayer(unittest.TestCase):
 
     def setUp(self):
         self.locations = [(-5.0, 5.0), (10.0, 10.0)]
+        self.kwargs = {
+            "hover_text": "",
+            "label": "",
+            "info_box_content": ""
+        }
+
+    def _add_default_options(self, **options):
+        new_options = self.kwargs.copy()
+        new_options.update(options)
+        return new_options
 
     def test_hover_text_atomic(self):
-        marker_options = _marker_layer_options(
-            self.locations, hover_text="test-text",
-            label="", info_box_content="")
+        options = self._add_default_options(hover_text="test-text")
+        marker_options = _marker_layer_options(self.locations, **options)
         for options in marker_options:
             assert options["hover_text"] == "test-text"
 
     def test_hover_text_lists(self):
-        marker_options = _marker_layer_options(
-            self.locations, hover_text=["t1", "t2"], label="",
-            info_box_content="")
-        hover_texts = [options["hover_text"] for options in marker_options]
+        options = self._add_default_options(hover_text=["t1", "t2"])
+        marker_options = _marker_layer_options(self.locations, **options)
+        hover_texts = [opts["hover_text"] for opts in marker_options]
         assert tuple(hover_texts) == ("t1", "t2")
 
     def test_infobox_text_atomic(self):
-        marker_options = _marker_layer_options(
-            self.locations, info_box_content="<h3>test-html-infobox</h3>",
-            label="", hover_text="")
+        test_content = "<h3>test-html-infobox</h3>"
+        options = self._add_default_options(info_box_content=test_content)
+        marker_options = _marker_layer_options(self.locations, **options)
         for options in marker_options:
-            assert options["info_box_content"] == "<h3>test-html-infobox</h3>"
+            assert options["info_box_content"] == test_content
 
     def test_infobox_text_lists(self):
-        marker_options = _marker_layer_options(
-            self.locations,
-            info_box_content=["<h1>h1</h1>", "<h2>h2</h2>"], label="",
-            hover_text="")
-        infos = [options["info_box_content"] for options in marker_options]
-        assert tuple(infos) == ("<h1>h1</h1>", "<h2>h2</h2>")
+        test_content = ["<h1>h1</h1>", "<h2>h2</h2>"]
+        options = self._add_default_options(info_box_content=test_content)
+        marker_options = _marker_layer_options(self.locations, **options)
+        infos = [opts["info_box_content"] for opts in marker_options]
+        assert tuple(infos) == tuple(test_content)
 
 
 class SymbolLayer(unittest.TestCase):

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -53,6 +53,14 @@ class MarkerLayer(unittest.TestCase):
         assert tuple(info_contents) == tuple(test_content)
         assert tuple(display_infos) == tuple(test_display_info_box)
 
+    def test_infobox_default_display(self):
+        test_content = "test-content"
+        options = self._add_default_options(
+            info_box_content=test_content)
+        marker_options = _marker_layer_options(self.locations, **options)
+        for options in marker_options:
+            assert options["display_info_box"]
+
 
 class SymbolLayer(unittest.TestCase):
 

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -74,9 +74,13 @@ class SymbolLayer(unittest.TestCase):
         self.locations = [(-5.0, 5.0), (10.0, 10.0)]
         self.kwargs = {
             "stroke_color": None,
-            "hover_text": "", "fill_color": "red", "scale": 5,
-            "fill_opacity": 1.0, "stroke_opacity": 1.0,
-            "info_box_content": ""
+            "hover_text": "",
+            "fill_color": "red",
+            "scale": 5,
+            "fill_opacity": 1.0,
+            "stroke_opacity": 1.0,
+            "info_box_content": None,
+            "display_info_box": None
         }
 
     def _add_default_options(self, **options):
@@ -111,3 +115,9 @@ class SymbolLayer(unittest.TestCase):
         symbol_options = _symbol_layer_options(self.locations, **options)
         colors = [opts["stroke_color"] for opts in symbol_options]
         assert tuple(colors) == (c1, c2)
+
+    def test_infobox_default(self):
+        options = self._add_default_options()
+        symbol_options = _symbol_layer_options(self.locations, **options)
+        for opts in symbol_options:
+            assert not opts["display_info_box"]

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -43,10 +43,15 @@ class MarkerLayer(unittest.TestCase):
 
     def test_infobox_text_lists(self):
         test_content = ["<h1>h1</h1>", "<h2>h2</h2>"]
-        options = self._add_default_options(info_box_content=test_content)
+        test_display_info_box = [True, False]
+        options = self._add_default_options(
+            info_box_content=test_content,
+            display_info_box=test_display_info_box)
         marker_options = _marker_layer_options(self.locations, **options)
-        infos = [opts["info_box_content"] for opts in marker_options]
-        assert tuple(infos) == tuple(test_content)
+        info_contents = [opts["info_box_content"] for opts in marker_options]
+        display_infos = [opts["display_info_box"] for opts in marker_options]
+        assert tuple(info_contents) == tuple(test_content)
+        assert tuple(display_infos) == tuple(test_display_info_box)
 
 
 class SymbolLayer(unittest.TestCase):

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -73,33 +73,41 @@ class SymbolLayer(unittest.TestCase):
     def setUp(self):
         self.locations = [(-5.0, 5.0), (10.0, 10.0)]
         self.kwargs = {
+            "stroke_color": None,
             "hover_text": "", "fill_color": "red", "scale": 5,
-            "fill_opacity": 1.0, "stroke_opacity": 1.0, "info_box_content": ""
+            "fill_opacity": 1.0, "stroke_opacity": 1.0,
+            "info_box_content": ""
         }
 
+    def _add_default_options(self, **options):
+        new_options = self.kwargs.copy()
+        new_options.update(options)
+        return new_options
+
     def test_stroke_color_atomic_text(self):
+        options = self._add_default_options(stroke_color="red")
         symbol_options = _symbol_layer_options(
-            self.locations, stroke_color="red", **self.kwargs)
+            self.locations, **options)
         for options in symbol_options:
             assert options["stroke_color"] == "red"
 
     def test_stroke_color_atomic_tuple(self):
         color = (10, 10, 10, 0.5)
-        symbol_options = _symbol_layer_options(
-            self.locations, stroke_color=color, **self.kwargs)
+        options = self._add_default_options(stroke_color=color)
+        symbol_options = _symbol_layer_options(self.locations, **options)
         for options in symbol_options:
             assert options["stroke_color"] == color
 
     def test_stroke_color_list_text(self):
-        symbol_options = _symbol_layer_options(
-            self.locations, stroke_color=["red", "green"], **self.kwargs)
-        opts = [options["stroke_color"] for options in symbol_options]
+        options = self._add_default_options(stroke_color=["red", "green"])
+        symbol_options = _symbol_layer_options(self.locations, **options)
+        opts = [opts["stroke_color"] for opts in symbol_options]
         assert tuple(opts) == ("red", "green")
 
     def test_stroke_color_list_tuples(self):
         c1 = (10, 10, 10, 0.5)
         c2 = (20, 20, 20, 0.5)
-        symbol_options = _symbol_layer_options(
-            self.locations, stroke_color=[c1, c2], **self.kwargs)
-        opts = [options["stroke_color"] for options in symbol_options]
-        assert tuple(opts) == (c1, c2)
+        options = self._add_default_options(stroke_color=[c1, c2])
+        symbol_options = _symbol_layer_options(self.locations, **options)
+        colors = [opts["stroke_color"] for opts in symbol_options]
+        assert tuple(colors) == (c1, c2)

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -11,7 +11,8 @@ class MarkerLayer(unittest.TestCase):
         self.kwargs = {
             "hover_text": "",
             "label": "",
-            "info_box_content": ""
+            "info_box_content": "",
+            "display_info_box": None
         }
 
     def _add_default_options(self, **options):

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -32,7 +32,7 @@ class MarkerLayer(unittest.TestCase):
         hover_texts = [opts["hover_text"] for opts in marker_options]
         assert tuple(hover_texts) == ("t1", "t2")
 
-    def test_infobox_text_atomic(self):
+    def test_infobox_content_atomic(self):
         test_content = "<h3>test-html-infobox</h3>"
         options = self._add_default_options(
             info_box_content=test_content, display_info_box=True)
@@ -41,7 +41,7 @@ class MarkerLayer(unittest.TestCase):
             assert options["info_box_content"] == test_content
             assert options["display_info_box"]
 
-    def test_infobox_text_lists(self):
+    def test_infobox_content_lists(self):
         test_content = ["<h1>h1</h1>", "<h2>h2</h2>"]
         test_display_info_box = [True, False]
         options = self._add_default_options(
@@ -121,3 +121,19 @@ class SymbolLayer(unittest.TestCase):
         symbol_options = _symbol_layer_options(self.locations, **options)
         for opts in symbol_options:
             assert not opts["display_info_box"]
+
+    def test_infobox_content_atomic(self):
+        test_content = "<h3>test-html-infobox</h3>"
+        options = self._add_default_options(
+            info_box_content=test_content, display_info_box=True)
+        symbol_options = _symbol_layer_options(self.locations, **options)
+        for options in symbol_options:
+            assert options["info_box_content"] == test_content
+            assert options["display_info_box"]
+
+    def test_infobox_default_display_lists(self):
+        test_content = ["1", None]
+        options = self._add_default_options(info_box_content=test_content)
+        marker_options = _symbol_layer_options(self.locations, **options)
+        display_infos = [opts["display_info_box"] for opts in marker_options]
+        assert tuple(display_infos) == (True, False)

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -34,10 +34,12 @@ class MarkerLayer(unittest.TestCase):
 
     def test_infobox_text_atomic(self):
         test_content = "<h3>test-html-infobox</h3>"
-        options = self._add_default_options(info_box_content=test_content)
+        options = self._add_default_options(
+            info_box_content=test_content, display_info_box=True)
         marker_options = _marker_layer_options(self.locations, **options)
         for options in marker_options:
             assert options["info_box_content"] == test_content
+            assert options["display_info_box"]
 
     def test_infobox_text_lists(self):
         test_content = ["<h1>h1</h1>", "<h2>h2</h2>"]

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -11,7 +11,7 @@ class MarkerLayer(unittest.TestCase):
         self.kwargs = {
             "hover_text": "",
             "label": "",
-            "info_box_content": "",
+            "info_box_content": None,
             "display_info_box": None
         }
 
@@ -55,11 +55,17 @@ class MarkerLayer(unittest.TestCase):
 
     def test_infobox_default_display(self):
         test_content = "test-content"
-        options = self._add_default_options(
-            info_box_content=test_content)
+        options = self._add_default_options(info_box_content=test_content)
         marker_options = _marker_layer_options(self.locations, **options)
         for options in marker_options:
             assert options["display_info_box"]
+
+    def test_infobox_default_display_lists(self):
+        test_content = ["1", None]
+        options = self._add_default_options(info_box_content=test_content)
+        marker_options = _marker_layer_options(self.locations, **options)
+        display_infos = [opts["display_info_box"] for opts in marker_options]
+        assert tuple(display_infos) == (True, False)
 
 
 class SymbolLayer(unittest.TestCase):

--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -242,7 +242,7 @@ export const BaseMarkerView = widgets.WidgetView.extend({
         infoBoxProperties.forEach(([nameInView, nameInModel]) => {
             const callback = (
                 () => {
-                    this.infoWindow.set(
+                    this.infoBox.set(
                     nameInView, this.model.get(nameInModel))
                 }
             )

--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -184,6 +184,8 @@ export const BaseMarkerView = widgets.WidgetView.extend({
         }
         this.marker = new google.maps.Marker(markerOptions)
         this.infoBox = this.renderInfoBox()
+        this.infoBoxListener = null;
+        this.mapView = null;
         this.modelEvents()
     },
 
@@ -198,14 +200,24 @@ export const BaseMarkerView = widgets.WidgetView.extend({
         return infoBox ;
     },
 
-    addToMapView(mapView) {
-        this.marker.setMap(mapView.map);
+    toggleInfoBoxListener() {
         if (this.displayInfoBox()) {
-            this.marker.addListener(
+            this.infoBoxListener = this.marker.addListener(
                 "click",
-                () => { this.infoBox.open(mapView.map, this.marker) }
+                () => { this.infoBox.open(this.mapView.map, this.marker) }
             )
         }
+        else {
+            if (this.infoBoxListener !== null) {
+                this.infoBoxListener.remove()
+            }
+        }
+    },
+
+    addToMapView(mapView) {
+        this.mapView = mapView;
+        this.marker.setMap(mapView.map);
+        this.toggleInfoBoxListener();
     },
 
     modelEvents() {
@@ -236,6 +248,10 @@ export const BaseMarkerView = widgets.WidgetView.extend({
             )
             this.model.on(`change:${nameInModel}`, callback, this)
         })
+
+        this.model.on("change:display_info_box", () => {
+            this.toggleInfoBoxListener()
+        }, this)
 
         this.setStyleEvents()
     }

--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -184,8 +184,11 @@ export const BaseMarkerView = widgets.WidgetView.extend({
         }
         this.marker = new google.maps.Marker(markerOptions)
         this.infoBox = this.renderInfoBox()
-        this.displayInfoBox = this.model.get("display_info_box")
         this.modelEvents()
+    },
+
+    displayInfoBox() {
+        return this.model.get("display_info_box");
     },
 
     renderInfoBox() {
@@ -196,13 +199,11 @@ export const BaseMarkerView = widgets.WidgetView.extend({
     },
 
     addToMapView(mapView) {
-        let marker = this.marker;
-        let infoWindow = this.infoWindow;
-        marker.setMap(mapView.map);
-        if (this.displayInfoBox) {
-            marker.addListener(
-                'click',
-                () => { this.infoBox.open(mapView.map, marker) }
+        this.marker.setMap(mapView.map);
+        if (this.displayInfoBox()) {
+            this.marker.addListener(
+                "click",
+                () => { this.infoBox.open(mapView.map, this.marker) }
             )
         }
     },

--- a/js/src/jupyter-gmaps.js
+++ b/js/src/jupyter-gmaps.js
@@ -184,7 +184,7 @@ export const BaseMarkerView = widgets.WidgetView.extend({
         }
         this.marker = new google.maps.Marker(markerOptions)
         this.infoBox = this.renderInfoBox()
-        this.showInfoBox = this.model.get("show_info_box")
+        this.displayInfoBox = this.model.get("display_info_box")
         this.modelEvents()
     },
 
@@ -199,7 +199,7 @@ export const BaseMarkerView = widgets.WidgetView.extend({
         let marker = this.marker;
         let infoWindow = this.infoWindow;
         marker.setMap(mapView.map);
-        if (this.showInfoBox) {
+        if (this.displayInfoBox) {
             marker.addListener(
                 'click',
                 () => { this.infoBox.open(mapView.map, marker) }


### PR DESCRIPTION
Info-boxes show up even when their content is empty. This is a regression since the user has no way to specify that they don't want an info box.

This PR solves this by adding a `display_info_box` option to both the widgets and the factory functions. This can be set explicitly, or left as `None`, in which case it will default to `True` if the user has set a content for info boxes or `False` otherwise.