### PR TITLE
Force pip upgrade in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.5"
 install:
+  - "pip install -U pip"
   - "pip install -r requirements.txt"
   - "pip install flake8"
 before_script:


### PR DESCRIPTION
The Travis builds broke because some of the dependencies were not installing correctly. By default, Travis runs a fairly old version of pip (6.0.7 vs the current 9.0.1). pip6.0.7 doesn't seem to be able to find wheels for many of the packages, which makes the installation more complex. Forcing an update of pip before building fixes the problem.