### PR TITLE
Fix documentation on embedding

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -67,7 +67,7 @@ Additionally, you will need to import `jupyter-gmaps`, JQuery and the Bootstrap 
     </html>
 
     
-Thus, a valid HTML document containing a single map would look like:
+Thus, a valid HTML document containing a single map would look like this (the API key has been redacted, but apart from that, this will work out of the box):
 
 .. code-block:: html
 
@@ -78,7 +78,49 @@ Thus, a valid HTML document containing a single map would look like:
 
            <script src="https://unpkg.com/jupyter-js-widgets@~2.1.4/dist/embed.js"></script>
            <script type="application/vnd.jupyter.widget-state+json">
-               // widget state
+           {
+               "version_major": 1,
+               "version_minor": 0,
+               "state": {
+                   "acd855c3e79c4100bf23ac682b97fef6": {
+                       "model_name": "LayoutModel",
+                       "model_module": "jupyter-js-widgets",
+                       "model_module_version": "~2.1.4",
+                       "state": {
+                           "_model_module_version": "~2.1.4",
+                           "height": "400px",
+                           "_view_module_version": "~2.1.4",
+                           "align_self": "stretch"
+                       }
+                   },
+                   "e6333a5e4408424fa1d13bafe32e3ec8": {
+                       "model_name": "PlainmapModel",
+                       "model_module": "jupyter-gmaps",
+                       "model_module_version": "*",
+                       "state": {
+                           "layers": [],
+                           "_dom_classes": [],
+                           "msg_throttle": 1,
+                           "_model_module_version": "*",
+                           "_view_module_version": "*",
+                           "data_bounds": [
+                               [
+                                   46.2,
+                                   6.1
+                               ],
+                               [
+                                   47.2,
+                                   7.1
+                               ]
+                           ],
+                           "layout": "IPY_MODEL_acd855c3e79c4100bf23ac682b97fef6",
+                           "configuration": {
+                               "api_key": "AIza_FILL_ME_IN"
+                           }
+                       }
+                   }
+               }
+           }
            </script>
 
        </head>

--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -130,7 +130,7 @@ Thus, a valid HTML document containing a single map would look like this (the AP
            <div id="widget-embedded-here">
                <script type="application/vnd.jupyter.widget-view+json">
                {
-                   "model_id": "c05e9b0ca0dd405295d2adde29776c95"
+                   "model_id": "e6333a5e4408424fa1d13bafe32e3ec8"
                }
                </script>
            </div>

--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -55,7 +55,6 @@ Additionally, you will need to import `jupyter-gmaps`, JQuery and the Bootstrap 
         <head>
             <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
             <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
-            <script src="https://unpkg.com/jupyter-gmaps@*/dist/index.js"></script>
 
             {{ paste first two script tags here }}
 
@@ -76,7 +75,6 @@ Thus, a valid HTML document containing a single map would look like:
        <head>
            <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
            <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
-           <script src="https://unpkg.com/jupyter-gmaps@*/dist/index.js"></script>
 
            <script src="https://unpkg.com/jupyter-js-widgets@~2.1.4/dist/embed.js"></script>
            <script type="application/vnd.jupyter.widget-state+json">


### PR DESCRIPTION
The documentation on embedding gmaps in HTML documents was both wrong and not particularly helpful. Now somewhat improved.

This addresses issue #140 in particular.