### PR TITLE
Better handling of errors when downloading maps as PNGs

### DIFF
--- a/gmaps/errors_box.py
+++ b/gmaps/errors_box.py
@@ -1,0 +1,15 @@
+
+import ipywidgets as widgets
+
+from traitlets import Unicode, List
+
+
+class ErrorsBox(widgets.DOMWidget):
+    """
+    Box to hold any JS errors that occur
+    """
+    _view_name = Unicode("ErrorsBoxView").tag(sync=True)
+    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
+    _model_name = Unicode("ErrorsBoxModel").tag(sync=True)
+    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
+    errors = List(trait=Unicode).tag(sync=True)

--- a/gmaps/figure.py
+++ b/gmaps/figure.py
@@ -59,13 +59,17 @@ class Figure(widgets.DOMWidget):
         self._map.add_layer(layer)
 
 
-def figure(display_toolbar=True):
+def figure(display_toolbar=True, display_errors=True):
     """
     Create a gmaps figure
 
     This returns a `Figure` object to which you can add data layers.
 
-    :param display_toolbar: Boolean denoting whether to show the toolbar.
+    :param display_toolbar:
+        Boolean denoting whether to show the toolbar. Defaults to True.
+
+    :param display_errors:
+        Boolean denoting whether to show errors that arise in the client.
         Defaults to True.
 
     :returns:
@@ -80,5 +84,5 @@ def figure(display_toolbar=True):
     """
     _map = Map()
     _toolbar = Toolbar() if display_toolbar else None
-    _errors_box = ErrorsBox()
+    _errors_box = ErrorsBox() if display_errors else None
     return Figure(_map=_map, _toolbar=_toolbar, _errors_box=_errors_box)

--- a/gmaps/figure.py
+++ b/gmaps/figure.py
@@ -5,6 +5,7 @@ from traitlets import Unicode, Instance
 
 from .maps import Map
 from .toolbar import Toolbar
+from .errors_box import ErrorsBox
 
 __all__ = ["Figure", "figure"]
 
@@ -22,6 +23,8 @@ class Figure(widgets.DOMWidget):
     _model_name = Unicode("FigureModel").tag(sync=True)
     _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     _toolbar = Instance(Toolbar, allow_none=True, default=None).tag(
+        sync=True, **widgets.widget_serialization)
+    _errors_box = Instance(ErrorsBox, allow_none=True, default=None).tag(
         sync=True, **widgets.widget_serialization)
     _map = Instance(Map).tag(sync=True, **widgets.widget_serialization)
 
@@ -77,4 +80,5 @@ def figure(display_toolbar=True):
     """
     _map = Map()
     _toolbar = Toolbar() if display_toolbar else None
-    return Figure(_map=_map, _toolbar=_toolbar)
+    _errors_box = ErrorsBox()
+    return Figure(_map=_map, _toolbar=_toolbar, _errors_box=_errors_box)

--- a/js/src/Directions.js
+++ b/js/src/Directions.js
@@ -16,6 +16,8 @@ export const DirectionsLayerModel = GMapsLayerModel.extend({
 
 
 export const DirectionsLayerView = GMapsLayerView.extend({
+    canDownloadAsPng: false,
+    
     render() {
         const rendererOptions = { map: this.mapView.map }
 

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -17,13 +17,21 @@ export const ErrorsBoxModel = widgets.DOMWidgetModel.extend({
 
 export const ErrorsBoxView = widgets.DOMWidgetView.extend({
     render() {
-        console.log('Hello erors view')
-        console.log(this.model.get('errors'));
+        this._renderErrors()
 
         this.listenTo(
             this.model,
             'change:errors',
-            () => console.log(this.model.get('errors'))
+            () => this._renderErrors()
         )
+    },
+
+    _renderErrors() {
+        const errorContainer = $('<ul />')
+        this.model.get('errors').map(
+            message => $(`<li>${message}</li>`)
+        ).forEach(element => errorContainer.append(element))
+        this.$el.empty(); // Clear the current state
+        this.$el.append(errorContainer);
     }
 });

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -1,4 +1,4 @@
-import widgets from 'jupyter-js-widgets'
+import widgets from 'jupyter-js-widgets';
 
 export const ErrorsBoxModel = widgets.DOMWidgetModel.extend({
     defaults: {
@@ -12,12 +12,14 @@ export const ErrorsBoxModel = widgets.DOMWidgetModel.extend({
 
     addError(errorMessage) {
         this.set('errors', this.get('errors').concat(errorMessage));
+        this.save_changes();
     },
 
     removeError(ierror) {
         const currentErrors = this.get('errors').slice();
         currentErrors.splice(ierror, 1);
         this.set('errors', currentErrors);
+        this.save_changes();
     }
 });
 

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -12,6 +12,12 @@ export const ErrorsBoxModel = widgets.DOMWidgetModel.extend({
 
     addError(errorMessage) {
         this.set('errors', this.get('errors').concat(errorMessage));
+    },
+
+    removeError(ierror) {
+        const currentErrors = this.get('errors').slice();
+        currentErrors.splice(ierror, 1);
+        this.set('errors', currentErrors);
     }
 });
 
@@ -29,7 +35,9 @@ export const ErrorsBoxView = widgets.DOMWidgetView.extend({
     _renderErrors() {
         const errorContainer = $('<ul />').addClass("gmaps-error-box")
         this.model.get('errors').map(
-            message => $(`<li><pre>${message}</pre></li>`)
+            (message, ierror) =>
+                $(`<li><pre>${message}</pre></li>`)
+                    .click(() => this.model.removeError(ierror))
         ).forEach(element => errorContainer.append(element))
         this.$el.empty(); // Clear the current state
         this.$el.append(errorContainer);

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -25,11 +25,7 @@ export const ErrorsBoxView = widgets.DOMWidgetView.extend({
     render() {
         this._renderErrors()
 
-        this.listenTo(
-            this.model,
-            'change:errors',
-            () => this._renderErrors()
-        )
+        this.model.on('change:errors', () => this._renderErrors())
     },
 
     _renderErrors() {

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -1,0 +1,19 @@
+import widgets from 'jupyter-js-widgets'
+
+export const ErrorsBoxModel = widgets.DOMWidgetModel.extend({
+    defaults: {
+        ...widgets.DOMWidgetModel.prototype.defaults,
+        _model_name: 'ErrorsBoxModel',
+        _view_name: 'ErrorsBoxView',
+        _model_module: 'jupyter-gmaps',
+        _view_module: 'jupyter-gmaps',
+        errors: []
+    }
+});
+
+export const ErrorsBoxView = widgets.DOMWidgetView.extend({
+    render() {
+        console.log('Hello erors view')
+        console.log(this.model.get('errors'));
+    }
+});

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -8,6 +8,10 @@ export const ErrorsBoxModel = widgets.DOMWidgetModel.extend({
         _model_module: 'jupyter-gmaps',
         _view_module: 'jupyter-gmaps',
         errors: []
+    },
+
+    addError(errorMessage) {
+        this.set('errors', this.get('errors').concat(errorMessage));
     }
 });
 
@@ -15,5 +19,11 @@ export const ErrorsBoxView = widgets.DOMWidgetView.extend({
     render() {
         console.log('Hello erors view')
         console.log(this.model.get('errors'));
+
+        this.listenTo(
+            this.model,
+            'change:errors',
+            () => console.log(this.model.get('errors'))
+        )
     }
 });

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -27,9 +27,9 @@ export const ErrorsBoxView = widgets.DOMWidgetView.extend({
     },
 
     _renderErrors() {
-        const errorContainer = $('<ul />')
+        const errorContainer = $('<ul />').addClass("gmaps-error-box")
         this.model.get('errors').map(
-            message => $(`<li>${message}</li>`)
+            message => $(`<li><pre>${message}</pre></li>`)
         ).forEach(element => errorContainer.append(element))
         this.$el.empty(); // Clear the current state
         this.$el.append(errorContainer);

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -49,9 +49,9 @@ export const FigureView = widgets.VBoxView.extend({
     },
 
     savePng() {
-        return this.mapView.then(view => {
+        return this.mapView.then(view =>
             view.savePng().catch(e => this.addError(e))
-        });
+        );
     },
 
     addError(errorMessage) {

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -44,7 +44,11 @@ export const FigureView = widgets.VBoxView.extend({
         else {
             this.toolbarView = null;
         }
-        this.errorsBoxView = this.add_child_model(this.model.get("_errors_box"));
+        const errorsBoxModel = this.model.get('_errors_box');
+        if (errorsBoxModel) {
+            this.errorsBoxView =
+                this.add_child_model(this.model.get("_errors_box"));
+        }
         this.mapView = this.add_child_model(this.model.get("_map"));
     },
 
@@ -55,7 +59,10 @@ export const FigureView = widgets.VBoxView.extend({
     },
 
     addError(errorMessage) {
-        console.log(errorMessage);
-        this.model.get("_errors_box").addError(errorMessage);
+        console.log(`[Error]: ${errorMessage}`)
+        const errorsBoxModel = this.model.get("_errors_box")
+        if (errorsBoxModel) {
+            errorsBoxModel.addError(errorMessage);
+        }
     }
 })

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -13,6 +13,7 @@ export const FigureModel = widgets.VBoxModel.extend({
         children: [],
         box_style: '',
         _map: undefined,
+        _errors_box: undefined,
         _toolbar: undefined
     }
 
@@ -21,6 +22,7 @@ export const FigureModel = widgets.VBoxModel.extend({
         children: {deserialize: widgets.unpack_models},
         _map: {deserialize: widgets.unpack_models},
         _toolbar: {deserialize: widgets.unpack_models},
+        _errors_box: {deserialize: widgets.unpack_models},
         ...widgets.DOMWidgetModel.serializers
     }
 })
@@ -42,6 +44,7 @@ export const FigureView = widgets.VBoxView.extend({
         else {
             this.toolbarView = null;
         }
+        this.errorsBoxView = this.add_child_model(this.model.get("_errors_box"));
         this.mapView = this.add_child_model(this.model.get("_map"));
     },
 

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -49,6 +49,13 @@ export const FigureView = widgets.VBoxView.extend({
     },
 
     savePng() {
-        return this.mapView.then(view => view.savePng());
+        return this.mapView.then(view => {
+            view.savePng().catch(e => this.addError(e))
+        });
+    },
+
+    addError(errorMessage) {
+        console.log(errorMessage);
+        this.model.get("_errors_box").addError(errorMessage);
     }
 })

--- a/js/src/GeoJson.js
+++ b/js/src/GeoJson.js
@@ -75,6 +75,9 @@ export const GeoJsonFeatureView = GMapsLayerView.extend({
 
 
 export const GeoJsonLayerView = GMapsLayerView.extend({
+
+    canDownloadAsPng: true,
+
     render() {
         this.featureViews = new widgets.ViewList(this.addFeature, null, this)
         this.featureViews.update(this.model.get("features"))

--- a/js/src/Heatmap.js
+++ b/js/src/Heatmap.js
@@ -23,6 +23,8 @@ export const WeightedHeatmapLayerModel = GMapsLayerModel.extend({
 
 
 const HeatmapLayerBaseView = GMapsLayerView.extend({
+    canDownloadAsPng: true,
+    
     render() {
         this.modelEvents() ;
         GoogleMapsLoader.load((google) => {

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -100,8 +100,14 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
                         .map(layer => layer.model.get('_view_name'))
                 )
                 const error = nonDownloadableLayers
-                    .then(layers => layers.join(', '))
-                    .then(text => Promise.reject(`Cannot download layers: ${text}`))
+                    .then(layers => {
+                        const layersText = layers.join(', ');
+                        const layersWord = layers.length > 1 ? 'layers' : 'layer';
+                        const errorMessage =
+                            `Cannot download ${layersWord}: ${layersText}. ` +
+                            `Remove these layers to export the map.`
+                        return Promise.reject(errorMessage)
+                    })
                 return error
             }
         })

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -1,9 +1,9 @@
 import widgets from 'jupyter-js-widgets'
 import _ from 'underscore'
-import { html2canvas } from './vendor/html2canvas'
 
 import GoogleMapsLoader from 'google-maps'
 
+import { downloadElementAsPng } from './services/downloadElement'
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';
 
 function needReloadGoogleMaps(configuration) {
@@ -91,7 +91,7 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
         )
         return canDownloadEveryLayer.then(canDownload => {
             if (canDownload) {
-                return this._saveMapPng()
+                return downloadElementAsPng(this.$el, 'map.png');
             }
             else {
                 const nonDownloadableLayers = allLayers.then(layers =>
@@ -106,25 +106,6 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
             }
         })
     },
-
-    _saveMapPng() {
-       return new Promise((resolve, reject) => {
-           html2canvas(this.$el, {
-               useCORS: true,
-               onrendered: (canvas) => {
-                   const a = document.createElement("a");
-                   a.download = "map.png";
-                   a.href = canvas.toDataURL("image/png");
-                   document.body.appendChild(a);
-                   a.click();
-                   resolve();
-               },
-               onerror: (error) => {
-                   reject(error);
-               }
-           })
-       })
-    }
 
 })
 

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -200,14 +200,15 @@ export const MarkerView = BaseMarkerView.extend({
 
 export const MarkerLayerView = GMapsLayerView.extend({
     canDownloadAsPng: true,
-    
+
     render() {
         this.markerViews = new widgets.ViewList(this.addMarker, null, this)
         this.markerViews.update(this.model.get("markers"))
     },
 
+    // No need to do anything here since the markers are added
+    // when they are deserialized
     addToMapView(mapView) {
-        this.markerViews.forEach(view => view.addToMapView(mapView))
     },
 
     addMarker(childModel) {

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -199,6 +199,8 @@ export const MarkerView = BaseMarkerView.extend({
 
 
 export const MarkerLayerView = GMapsLayerView.extend({
+    canDownloadAsPng: true,
+    
     render() {
         this.markerViews = new widgets.ViewList(this.addMarker, null, this)
         this.markerViews.update(this.model.get("markers"))

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -17,5 +17,6 @@ export * from './Heatmap';
 export * from './Marker';
 export * from './GeoJson';
 export * from './Directions';
+export * from './ErrorsBox'
 
 export { version } from '../package.json';

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -19,3 +19,14 @@
   margin-bottom: 0px !important;
   margin-right: 0px !important;
 }
+
+.gmaps-error-box {
+  padding-left: 0px;
+  margin-bottom: 0px;
+}
+
+.gmaps-error-box pre {
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin-bottom: 5px;
+}

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -30,3 +30,7 @@
   padding-bottom: 5px;
   margin-bottom: 5px;
 }
+
+.gmaps-error-box li {
+  cursor: pointer;
+}

--- a/js/src/services/downloadElement.js
+++ b/js/src/services/downloadElement.js
@@ -1,0 +1,22 @@
+import { html2canvas } from '../vendor/html2canvas'
+
+const downloadElementAsPng = ($element, downloadName) => {
+    return new Promise((resolve, reject) => {
+        html2canvas($element, {
+            useCORS: true,
+            onrendered: (canvas) => {
+                const a = document.createElement("a");
+                a.download = downloadName;
+                a.href = canvas.toDataURL("image/png");
+                document.body.appendChild(a);
+                a.click();
+                resolve();
+            },
+            onerror: (error) => {
+                reject(error);
+            }
+        })
+    });
+}
+
+export { downloadElementAsPng };


### PR DESCRIPTION
Prior to this PR, downloading figures as PNG was quite unreliable (issue #129 as well as general rendering issues).

This is improved by reverting to a stable version of html2canvas (PR #138). This works great, except when downloading maps containing directions (see e.g. [this](https://stackoverflow.com/questions/37457945/html2canvas-screenshot-of-a-div-element-containing-google-drive-directions-map) question on SO). This is probably acceptable (for now), but we need to give the user decent feedback. This PR introduces an error box in which to display errors like these.
<img width="666" alt="screen shot 2017-06-03 at 12 04 02" src="https://cloud.githubusercontent.com/assets/1392879/26753006/c459cff0-4854-11e7-95d5-9988ece1abc8.png">

