### PR TITLE
Modify rgba RegEx to allow 1.0 values for alpha

### DIFF
--- a/gmaps/geotraitlets.py
+++ b/gmaps/geotraitlets.py
@@ -59,7 +59,9 @@ _color_names = {
 
 _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
 _rgb_re = re.compile(r'rgb\([0-9]{1,3},[0-9]{1,3},[0-9]{1,3}\)')
-_rgba_re = re.compile(r'rgba\([0-9]{1,3},[0-9]{1,3},[0-9]{1,3},(?:0?\.[0-9]*|1\.0)\)')
+_rgba_re = re.compile(
+    r'rgba\([0-9]{1,3},[0-9]{1,3},[0-9]{1,3},(?:0?\.[0-9]*|1\.0)\)'
+)
 
 
 class ColorString(traitlets.Unicode):

--- a/gmaps/geotraitlets.py
+++ b/gmaps/geotraitlets.py
@@ -59,7 +59,7 @@ _color_names = {
 
 _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
 _rgb_re = re.compile(r'rgb\([0-9]{1,3},[0-9]{1,3},[0-9]{1,3}\)')
-_rgba_re = re.compile(r'rgba\([0-9]{1,3},[0-9]{1,3},[0-9]{1,3},0?\.[0-9]*\)')
+_rgba_re = re.compile(r'rgba\([0-9]{1,3},[0-9]{1,3},[0-9]{1,3},(?:0?\.[0-9]*|1\.0)\)')
 
 
 class ColorString(traitlets.Unicode):


### PR DESCRIPTION
Add a non-capturing OR group `(?:0?\.[0-9]*|1\.0)\)` instead of the prior regex which only had the first part of that `0?\.[0-9]*` 
Tested on a range of numbers from 0.0 to 1.1 .  Works on everything up to, and including 1.0 , but correctly errors on 1.1.