### PR TITLE
Cap latitude bounds to values allowed by Google maps

### DIFF
--- a/gmaps/bounds.py
+++ b/gmaps/bounds.py
@@ -41,11 +41,13 @@ def longitude_bounds(longitudes):
     Rsq = (1/N**2) * (sum_cos_sq + sum_sin_sq)
     standard_deviation = math.sqrt(-math.log(Rsq))
     extent = 2.0*math.degrees(standard_deviation)
-    extent = min(extent, 180.0 - EPSILON)
-
-    # centre the bound within [-180, 180]
-    lower_bound = ((mean_degrees - extent + 180.0) % 360.0) - 180.0
-    upper_bound = ((mean_degrees + extent + 180.0) % 360.0) - 180.0
+    if extent > 180.0:
+        # longitudes cover entire map
+        upper_bound = 180.0 - EPSILON
+        lower_bound = -upper_bound
+    else:
+        lower_bound = _normalize_longitude(mean_degrees - extent)
+        upper_bound = _normalize_longitude(mean_degrees + extent)
     return lower_bound, upper_bound
 
 

--- a/gmaps/bounds.py
+++ b/gmaps/bounds.py
@@ -3,6 +3,10 @@ import math
 
 EPSILON = 1e-5
 
+# GoogleMaps imposes latitude restrictions
+MAX_ALLOWED_LATITUDE = 85.0
+MIN_ALLOWED_LATITUDE = -85.0
+
 
 def latitude_bounds(latitudes):
     """
@@ -16,6 +20,8 @@ def latitude_bounds(latitudes):
     standard_deviation = math.sqrt(sum_squares/float(N))
     lower_bound = max(mean - 2.0*standard_deviation, -(90.0 - EPSILON))
     upper_bound = min(mean + 2.0*standard_deviation, (90.0 - EPSILON))
+    lower_bound = max(lower_bound, MIN_ALLOWED_LATITUDE)
+    upper_bound = min(upper_bound, MAX_ALLOWED_LATITUDE)
     return lower_bound, upper_bound
 
 

--- a/gmaps/tests/test_bounds.py
+++ b/gmaps/tests/test_bounds.py
@@ -3,7 +3,10 @@ import unittest
 
 import numpy as np
 
-from ..bounds import latitude_bounds, longitude_bounds, merge_longitude_bounds
+from ..bounds import (
+    latitude_bounds, longitude_bounds, merge_longitude_bounds,
+    MAX_ALLOWED_LATITUDE, MIN_ALLOWED_LATITUDE
+)
 
 
 class LatitudeBounds(unittest.TestCase):
@@ -17,15 +20,14 @@ class LatitudeBounds(unittest.TestCase):
     def test_latitude_whole_earth(self):
         latitudes = np.linspace(-89.0, 89.0, 100)
         lower, upper = latitude_bounds(latitudes)
-        assert -90.0 < lower < -89.0
-        assert 89.0 < upper < 90.0
+        assert lower == MIN_ALLOWED_LATITUDE
+        assert upper == MAX_ALLOWED_LATITUDE
 
     def test_extrema(self):
         latitudes = [89.0, -89.0]
         lower, upper = latitude_bounds(latitudes)
-        print(lower, upper)
-        assert -90.0 < lower < -87.0
-        assert 87.0 < upper < 90.0
+        assert lower == MIN_ALLOWED_LATITUDE
+        assert upper == MAX_ALLOWED_LATITUDE
 
 
 class LongitudeBounds(unittest.TestCase):


### PR DESCRIPTION
Google maps doesn't allow specifying latitude bounds above 85.0 or below -85.0. 