### PR TITLE
Use ES6 classes

### DIFF
--- a/js/src/Directions.js
+++ b/js/src/Directions.js
@@ -18,7 +18,10 @@ export class DirectionsLayerModel extends GMapsLayerModel {
 
 
 export class DirectionsLayerView extends GMapsLayerView {
-    static canDownloadAsPng = false
+    constructor(options) {
+        super(options);
+        this.canDownloadAsPng = false;
+    }
     
     render() {
         const rendererOptions = { map: this.mapView.map }

--- a/js/src/Directions.js
+++ b/js/src/Directions.js
@@ -6,17 +6,19 @@ import GoogleMapsLoader from 'google-maps';
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';
 
 
-export const DirectionsLayerModel = GMapsLayerModel.extend({
-    defaults: {
-        ...GMapsLayerModel.prototype.defaults,
-        _view_name: "DirectionsLayerView",
-        _model_name: "DirectionsLayerModel"
+export class DirectionsLayerModel extends GMapsLayerModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _view_name: "DirectionsLayerView",
+            _model_name: "DirectionsLayerModel"
+        }
     }
-});
+}
 
 
-export const DirectionsLayerView = GMapsLayerView.extend({
-    canDownloadAsPng: false,
+export class DirectionsLayerView extends GMapsLayerView {
+    static canDownloadAsPng = false
     
     render() {
         const rendererOptions = { map: this.mapView.map }
@@ -47,20 +49,19 @@ export const DirectionsLayerView = GMapsLayerView.extend({
                 }
             });
         });
-    },
+    }
 
-
-    addToMapView(mapView) { },
+    addToMapView(mapView) { }
 
     getOrigin(modelData) {
         const [lat, lng] = _.first(modelData)
         return new google.maps.LatLng(lat, lng)
-    },
+    }
 
     getDestination(modelData) {
         const [lat, lng] = _.last(modelData)
         return new google.maps.LatLng(lat, lng)
-    },
+    }
 
     getWaypoints(modelData) {
         const withoutFirst = _.tail(modelData)
@@ -70,4 +71,4 @@ export const DirectionsLayerView = GMapsLayerView.extend({
         })
         return dataAsGoogle
     }
-})
+}

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -1,19 +1,21 @@
 import widgets from 'jupyter-js-widgets';
 
-export const ErrorsBoxModel = widgets.DOMWidgetModel.extend({
-    defaults: {
-        ...widgets.DOMWidgetModel.prototype.defaults,
-        _model_name: 'ErrorsBoxModel',
-        _view_name: 'ErrorsBoxView',
-        _model_module: 'jupyter-gmaps',
-        _view_module: 'jupyter-gmaps',
-        errors: []
-    },
+export class ErrorsBoxModel extends widgets.DOMWidgetModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _model_name: 'ErrorsBoxModel',
+            _view_name: 'ErrorsBoxView',
+            _model_module: 'jupyter-gmaps',
+            _view_module: 'jupyter-gmaps',
+            errors: []
+        };
+    }
 
     addError(errorMessage) {
         this.set('errors', this.get('errors').concat(errorMessage));
         this.save_changes();
-    },
+    }
 
     removeError(ierror) {
         const currentErrors = this.get('errors').slice();
@@ -21,14 +23,14 @@ export const ErrorsBoxModel = widgets.DOMWidgetModel.extend({
         this.set('errors', currentErrors);
         this.save_changes();
     }
-});
+};
 
-export const ErrorsBoxView = widgets.DOMWidgetView.extend({
+
+export class ErrorsBoxView extends widgets.DOMWidgetView {
     render() {
         this._renderErrors()
-
         this.model.on('change:errors', () => this._renderErrors())
-    },
+    }
 
     _renderErrors() {
         const errorContainer = $('<ul />').addClass("gmaps-error-box")
@@ -40,4 +42,4 @@ export const ErrorsBoxView = widgets.DOMWidgetView.extend({
         this.$el.empty(); // Clear the current state
         this.$el.append(errorContainer);
     }
-});
+};

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -3,33 +3,34 @@ import _ from 'underscore';
 
 import widgets from 'jupyter-js-widgets';
 
-export const FigureModel = widgets.VBoxModel.extend({
-    defaults: {
-        ...widgets.DOMWidgetModel.prototype.defaults,
-        _model_name: "FigureModel",
-        _view_name: "FigureView",
-        _model_module: "jupyter-gmaps",
-        _view_module: "jupyter-gmaps",
-        children: [],
-        box_style: '',
-        _map: undefined,
-        _errors_box: undefined,
-        _toolbar: undefined
+export class FigureModel extends widgets.VBoxModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _model_name: "FigureModel",
+            _view_name: "FigureView",
+            _model_module: "jupyter-gmaps",
+            _view_module: "jupyter-gmaps",
+            children: [],
+            box_style: '',
+            _map: undefined,
+            _errors_box: undefined,
+            _toolbar: undefined
+        }
     }
 
-}, {
-    serializers: {
+    static serializers = {
+        ...widgets.DOMWidgetModel.serializers,
         children: {deserialize: widgets.unpack_models},
         _map: {deserialize: widgets.unpack_models},
         _toolbar: {deserialize: widgets.unpack_models},
-        _errors_box: {deserialize: widgets.unpack_models},
-        ...widgets.DOMWidgetModel.serializers
+        _errors_box: {deserialize: widgets.unpack_models}
     }
-})
+}
 
-export const FigureView = widgets.VBoxView.extend({
+export class FigureView extends widgets.VBoxView {
     initialize(parameters) {
-        FigureView.__super__.initialize.apply(this, arguments)
+        super.initialize(parameters)
         const toolbarModel = this.model.get("_toolbar");
         if(toolbarModel) {
             this.toolbarView =
@@ -50,13 +51,13 @@ export const FigureView = widgets.VBoxView.extend({
                 this.add_child_model(this.model.get("_errors_box"));
         }
         this.mapView = this.add_child_model(this.model.get("_map"));
-    },
+    }
 
     savePng() {
         return this.mapView.then(view =>
             view.savePng().catch(e => this.addError(e))
         );
-    },
+    }
 
     addError(errorMessage) {
         console.log(`[Error]: ${errorMessage}`)
@@ -65,4 +66,4 @@ export const FigureView = widgets.VBoxView.extend({
             errorsBoxModel.addError(errorMessage);
         }
     }
-})
+}

--- a/js/src/GMapsLayer.js
+++ b/js/src/GMapsLayer.js
@@ -1,19 +1,21 @@
 import widgets from 'jupyter-js-widgets';
 
-export const GMapsLayerView = widgets.WidgetView.extend({
+export class GMapsLayerView extends widgets.WidgetView {
     initialize(parameters) {
-        GMapsLayerView.__super__.initialize.apply(this, arguments)
+        super.initialize(parameters)
         this.mapView = this.options.mapView
     }
-});
+};
 
 
-export const GMapsLayerModel = widgets.WidgetModel.extend({
-    defaults: {
-        ...widgets.WidgetModel.prototype.defaults,
-        _view_name : 'GMapsLayerView',
-        _model_name : 'GMapsLayerModel',
-        _view_module : 'jupyter-gmaps',
-        _model_module : 'jupyter-gmaps'
+export class GMapsLayerModel extends widgets.WidgetModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _view_name : 'GMapsLayerView',
+            _model_name : 'GMapsLayerModel',
+            _view_module : 'jupyter-gmaps',
+            _model_module : 'jupyter-gmaps'
+        }
     }
-});
+}

--- a/js/src/GeoJson.js
+++ b/js/src/GeoJson.js
@@ -79,7 +79,10 @@ export class GeoJsonFeatureView extends GMapsLayerView {
 
 export class GeoJsonLayerView extends GMapsLayerView {
 
-    static canDownloadAsPng = true
+    constructor(options) {
+        super(options);
+        this.canDownloadAsPng = true;
+    }
 
     render() {
         this.featureViews = new widgets.ViewList(this.addFeature, null, this)

--- a/js/src/Heatmap.js
+++ b/js/src/Heatmap.js
@@ -27,8 +27,12 @@ export class WeightedHeatmapLayerModel extends GMapsLayerModel {
 
 
 class HeatmapLayerBaseView extends GMapsLayerView {
-    static canDownloadAsPng = true
-    
+
+    constructor(options) {
+        super(options)
+        this.canDownloadAsPng = true;
+    }
+
     render() {
         this.modelEvents() ;
         GoogleMapsLoader.load((google) => {

--- a/js/src/Heatmap.js
+++ b/js/src/Heatmap.js
@@ -4,26 +4,30 @@ import GoogleMapsLoader from 'google-maps'
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';
 
 
-export const SimpleHeatmapLayerModel = GMapsLayerModel.extend({
-    defaults: {
-        ...GMapsLayerModel.prototype.defaults,
-        _view_name: "SimpleHeatmapLayerView",
-        _model_name: "SimpleHeatmapLayerModel"
+export class SimpleHeatmapLayerModel extends GMapsLayerModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _view_name: "SimpleHeatmapLayerView",
+            _model_name: "SimpleHeatmapLayerModel"
+        }
     }
-});
+};
 
 
-export const WeightedHeatmapLayerModel = GMapsLayerModel.extend({
-    defaults: {
-        ...GMapsLayerModel.prototype.defaults,
-        _view_name: "WeightedHeatmapLayerView",
-        _model_name: "WeightedHeatmapLayerModel"
+export class WeightedHeatmapLayerModel extends GMapsLayerModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _view_name: "WeightedHeatmapLayerView",
+            _model_name: "WeightedHeatmapLayerModel"
+        }
     }
-});
+};
 
 
-const HeatmapLayerBaseView = GMapsLayerView.extend({
-    canDownloadAsPng: true,
+class HeatmapLayerBaseView extends GMapsLayerView {
+    static canDownloadAsPng = true
     
     render() {
         this.modelEvents() ;
@@ -37,11 +41,11 @@ const HeatmapLayerBaseView = GMapsLayerView.extend({
                 gradient: this.model.get("gradient")
             }) ;
         });
-    },
+    }
 
     addToMapView(mapView) {
         this.heatmap.setMap(mapView.map)
-    },
+    }
 
     modelEvents() {
         // Simple properties:
@@ -59,14 +63,11 @@ const HeatmapLayerBaseView = GMapsLayerView.extend({
             )
             this.model.on(`change:${nameInModel}`, callback, this)
         })
-    },
-
-    get_data() {},
-
-})
+    }
+}
 
 
-export const SimpleHeatmapLayerView = HeatmapLayerBaseView.extend({
+export class SimpleHeatmapLayerView extends HeatmapLayerBaseView {
     getData() {
         const data = this.model.get("data")
         const dataAsGoogle = new google.maps.MVCArray(
@@ -74,10 +75,10 @@ export const SimpleHeatmapLayerView = HeatmapLayerBaseView.extend({
         )
         return dataAsGoogle
     }
-})
+}
 
 
-export const WeightedHeatmapLayerView = HeatmapLayerBaseView.extend({
+export class WeightedHeatmapLayerView extends HeatmapLayerBaseView {
     getData() {
         const data = this.model.get("data")
         const dataAsGoogle = new google.maps.MVCArray(
@@ -88,4 +89,4 @@ export const WeightedHeatmapLayerView = HeatmapLayerBaseView.extend({
         );
         return dataAsGoogle
     }
-})
+}

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -121,7 +121,7 @@ export class PlainmapView extends ConfigurationMixin(widgets.DOMWidgetView) {
 export class PlainmapModel extends widgets.DOMWidgetModel {
     defaults() {
         return {
-            ...widgets.DOMWidgetModel.prototype.defaults,
+            ...super.defaults(),
             _view_name: "PlainmapView",
             _model_name: "PlainmapModel",
             _view_module : 'jupyter-gmaps',

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -26,7 +26,7 @@ function reloadGoogleMaps(configuration) {
 
 // Mixins
 
-const ConfigurationMixin = {
+const ConfigurationMixin = (superclass) => class extends superclass {
     loadConfiguration() {
         const modelConfiguration = this.model.get("configuration")
         reloadGoogleMaps(modelConfiguration)
@@ -36,7 +36,8 @@ const ConfigurationMixin = {
 
 // Views
 
-export const PlainmapView = widgets.DOMWidgetView.extend({
+export class PlainmapView extends ConfigurationMixin(widgets.DOMWidgetView) {
+
     render() {
         this.loadConfiguration();
         this.el.style["width"] = this.model.get("width");
@@ -61,11 +62,11 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
                 }, 500);
             })
         })
-    },
+    }
 
     modelEvents() {
         this.model.on("change:data_bounds", this.updateBounds, this);
-    },
+    }
 
     updateBounds(bounds) {
         const [[latBL, lngBL], [latTR, lngTR]] = bounds
@@ -73,7 +74,7 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
         const boundTR = new google.maps.LatLng(latTR, lngTR)
         const boundsAsGoogle = new google.maps.LatLngBounds(boundBL, boundTR)
         this.map.fitBounds(boundsAsGoogle);
-    },
+    }
 
     addLayerModel(childModel) {
         return this.create_child_view(
@@ -82,7 +83,7 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
             childView.addToMapView(this) ;
             return childView;
         })
-    },
+    }
 
     savePng() {
         const allLayers = Promise.all(this.layerViews.views);
@@ -111,29 +112,28 @@ export const PlainmapView = widgets.DOMWidgetView.extend({
                 return error
             }
         })
-    },
+    }
 
-})
-
-_.extend(PlainmapView.prototype, ConfigurationMixin);
-
+}
 
 // Models
 
-export const PlainmapModel = widgets.DOMWidgetModel.extend({
-    defaults: {
-        ...widgets.DOMWidgetModel.prototype.defaults,
-        _view_name: "PlainmapView",
-        _model_name: "PlainmapModel",
-        _view_module : 'jupyter-gmaps',
-        _model_module : 'jupyter-gmaps',
-        width: "600px",
-        height: "400px",
-        data_bounds: null
+export class PlainmapModel extends widgets.DOMWidgetModel {
+    defaults() {
+        return {
+            ...widgets.DOMWidgetModel.prototype.defaults,
+            _view_name: "PlainmapView",
+            _model_name: "PlainmapModel",
+            _view_module : 'jupyter-gmaps',
+            _model_module : 'jupyter-gmaps',
+            width: "600px",
+            height: "400px",
+            data_bounds: null
+        };
     }
-}, {
-    serializers: {
+        
+    static serializers = {
+        ...widgets.DOMWidgetModel.serializers,
         layers: {deserialize: widgets.unpack_models},
-        ...widgets.DOMWidgetModel.serializers
     }
-});
+}

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -203,7 +203,10 @@ export class MarkerView extends BaseMarkerView {
 
 
 export class MarkerLayerView extends GMapsLayerView {
-    static canDownloadAsPng = true
+    constructor(options) {
+        super(options);
+        this.canDownloadAsPng = true;
+    }
 
     render() {
         this.markerViews = new widgets.ViewList(this.addMarker, null, this)

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -18,7 +18,7 @@ export class SymbolModel extends GMapsLayerModel {
 export class MarkerModel extends GMapsLayerModel {
     defaults() {
         return {
-            ...GMapsLayerModel.prototype.defaults,
+            ...super.defaults(),
             _view_name: "MarkerView",
             _model_name: "MarkerModel"
         }
@@ -29,7 +29,7 @@ export class MarkerModel extends GMapsLayerModel {
 export class MarkerLayerModel extends GMapsLayerModel {
     defaults() {
         return {
-            ...GMapsLayerModel.prototype.defaults,
+            ...super.defaults(),
             _view_name: "MarkerLayerView",
             _model_name: "MarkerLayerModel"
         }

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -4,36 +4,42 @@ import widgets from 'jupyter-js-widgets';
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';
 
 
-export const SymbolModel = GMapsLayerModel.extend({
-    defaults: {
-        ...GMapsLayerModel.prototype.defaults,
-        _view_name: "SymbolView",
-        _model_name: "SymbolModel"
+export class SymbolModel extends GMapsLayerModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _view_name: "SymbolView",
+            _model_name: "SymbolModel"
+        }
     }
-})
+}
 
 
-export const MarkerModel = GMapsLayerModel.extend({
-    defaults: {
-        ...GMapsLayerModel.prototype.defaults,
-        _view_name: "MarkerView",
-        _model_name: "MarkerModel"
+export class MarkerModel extends GMapsLayerModel {
+    defaults() {
+        return {
+            ...GMapsLayerModel.prototype.defaults,
+            _view_name: "MarkerView",
+            _model_name: "MarkerModel"
+        }
     }
-})
+}
 
 
-export const MarkerLayerModel = GMapsLayerModel.extend({
-    defaults: {
-        ...GMapsLayerModel.prototype.defaults,
-        _view_name: "MarkerLayerView",
-        _model_name: "MarkerLayerModel"
+export class MarkerLayerModel extends GMapsLayerModel {
+    defaults() {
+        return {
+            ...GMapsLayerModel.prototype.defaults,
+            _view_name: "MarkerLayerView",
+            _model_name: "MarkerLayerModel"
+        }
     }
-}, {
-    serializers: {
-        markers: {deserialize: widgets.unpack_models},
-        ...widgets.DOMWidgetModel.serializers
+
+    static serializers = {
+        ...widgets.DOMWidgetModel.serializers,
+        markers: {deserialize: widgets.unpack_models}
     }
-})
+}
 
 
 /* Base class for markers.
@@ -44,7 +50,7 @@ export const MarkerLayerModel = GMapsLayerModel.extend({
  * to add to the marker, and `setStyleEvents`, which must set
  * up events for those styles.
  */
-const BaseMarkerView = widgets.WidgetView.extend({
+class BaseMarkerView extends widgets.WidgetView {
     render() {
         const [lat, lng] = this.model.get("location")
         const title = this.model.get("hover_text")
@@ -60,18 +66,18 @@ const BaseMarkerView = widgets.WidgetView.extend({
         this.infoBoxListener = null;
         this.mapView = null;
         this.modelEvents()
-    },
+    }
 
     displayInfoBox() {
         return this.model.get("display_info_box");
-    },
+    }
 
     renderInfoBox() {
         const infoBox = new google.maps.InfoWindow({
             content: this.model.get("info_box_content")
         });
         return infoBox ;
-    },
+    }
 
     toggleInfoBoxListener() {
         if (this.displayInfoBox()) {
@@ -85,13 +91,13 @@ const BaseMarkerView = widgets.WidgetView.extend({
                 this.infoBoxListener.remove()
             }
         }
-    },
+    }
 
     addToMapView(mapView) {
         this.mapView = mapView;
         this.marker.setMap(mapView.map);
         this.toggleInfoBoxListener();
-    },
+    }
 
     modelEvents() {
         // Simple properties:
@@ -128,11 +134,9 @@ const BaseMarkerView = widgets.WidgetView.extend({
 
         this.setStyleEvents()
     }
+}
 
-
-})
-
-export const SymbolView = BaseMarkerView.extend({
+export class SymbolView extends BaseMarkerView {
 
     getStyleOptions() {
         const fillColor = this.model.get("fill_color")
@@ -150,7 +154,7 @@ export const SymbolView = BaseMarkerView.extend({
                 strokeOpacity
             }
         }
-    },
+    }
 
     setStyleEvents() {
         const iconProperties = [
@@ -169,16 +173,16 @@ export const SymbolView = BaseMarkerView.extend({
             this.model.on(`change:${nameInModel}`, callback, this)
         })
     }
-})
+}
 
 
-export const MarkerView = BaseMarkerView.extend({
+export class MarkerView extends BaseMarkerView {
 
     getStyleOptions() {
         this.modelEvents()
         const label = this.model.get("label")
         return { label }
-    },
+    }
 
     setStyleEvents() {
         const properties = [
@@ -195,21 +199,20 @@ export const MarkerView = BaseMarkerView.extend({
         })
     }
 
-})
+}
 
 
-export const MarkerLayerView = GMapsLayerView.extend({
-    canDownloadAsPng: true,
+export class MarkerLayerView extends GMapsLayerView {
+    static canDownloadAsPng = true
 
     render() {
         this.markerViews = new widgets.ViewList(this.addMarker, null, this)
         this.markerViews.update(this.model.get("markers"))
-    },
+    }
 
     // No need to do anything here since the markers are added
     // when they are deserialized
-    addToMapView(mapView) {
-    },
+    addToMapView(mapView) { }
 
     addMarker(childModel) {
         return this.create_child_view(childModel)
@@ -218,4 +221,4 @@ export const MarkerLayerView = GMapsLayerView.extend({
                 return childView
             })
     }
-})
+}

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -1,16 +1,18 @@
 import widgets from 'jupyter-js-widgets'
 
-export const ToolbarModel = widgets.DOMWidgetModel.extend({
-    defaults: {
-        ...widgets.DOMWidgetModel.prototype.defaults,
-        _model_name: "ToolbarModel",
-        _view_name: "ToolbarView",
-        _model_module: "jupyter-gmaps",
-        _view_module: "jupyter-gmaps",
+export class ToolbarModel extends widgets.DOMWidgetModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _model_name: "ToolbarModel",
+            _view_name: "ToolbarView",
+            _model_module: "jupyter-gmaps",
+            _view_module: "jupyter-gmaps",
+        }
     }
-});
+};
 
-export const ToolbarView = widgets.DOMWidgetView.extend({
+export class ToolbarView extends widgets.DOMWidgetView {
 
     render() {
         const $toolbar = $("<div />");
@@ -60,10 +62,10 @@ export const ToolbarView = widgets.DOMWidgetView.extend({
         this.$el.append($toolbar)
 
         this.update();
-    },
+    }
 
     registerSavePngCallback(callback) {
         this.savePngCallback = callback;
     }
-})
+}
 


### PR DESCRIPTION
It's 2017. ES6 classes offer a much nicer syntax than Backbone's `extend`.

This PR should have no effect on the functionality. It just makes the JS code easier to read and write.