### PR TITLE
Added case for a single location

### DIFF
--- a/gmaps/bounds.py
+++ b/gmaps/bounds.py
@@ -13,15 +13,19 @@ def latitude_bounds(latitudes):
     Estimate latitude bound with 2*sample standard deviation
     """
     N = float(len(latitudes))
-    mean = sum(latitudes) / N
-    sum_squares = sum(
-        (latitude-mean)**2 for latitude in latitudes
-    )
-    standard_deviation = math.sqrt(sum_squares/float(N))
-    lower_bound = max(mean - 2.0*standard_deviation, -(90.0 - EPSILON))
-    upper_bound = min(mean + 2.0*standard_deviation, (90.0 - EPSILON))
-    lower_bound = max(lower_bound, MIN_ALLOWED_LATITUDE)
-    upper_bound = min(upper_bound, MAX_ALLOWED_LATITUDE)
+    if N == 1.0:
+        lower_bound = latitudes[0] - EPSILON
+        upper_bound = latitudes[0] + EPSILON
+    else:
+        mean = sum(latitudes) / N
+        sum_squares = sum(
+            (latitude-mean)**2 for latitude in latitudes
+        )
+        standard_deviation = math.sqrt(sum_squares/float(N))
+        lower_bound = max(mean - 2.0*standard_deviation, -(90.0 - EPSILON))
+        upper_bound = min(mean + 2.0*standard_deviation, (90.0 - EPSILON))
+        lower_bound = max(lower_bound, MIN_ALLOWED_LATITUDE)
+        upper_bound = min(upper_bound, MAX_ALLOWED_LATITUDE)
     return lower_bound, upper_bound
 
 
@@ -37,8 +41,11 @@ def longitude_bounds(longitudes):
     for how to calculate the relevant statistics.
     """
     N = float(len(longitudes))
-    # Change to N > 1 and N == 1 cases
-    if N > 1:
+    # Change to N == 1 and N > 1 cases
+    if N == 1:
+        lower_bound = longitudes[0] - EPSILON
+        upper_bound = longitudes[0] + EPSILON
+    else:
         radians = [math.radians(longitude) for longitude in longitudes]
         sum_cos = sum(math.cos(r) for r in radians)
         sum_cos_sq = sum_cos**2
@@ -56,8 +63,6 @@ def longitude_bounds(longitudes):
         else:
             lower_bound = _normalize_longitude(mean_degrees - extent)
             upper_bound = _normalize_longitude(mean_degrees + extent)
-    elif N == 1:
-        lower_bound = upper_bound = longitudes[0]
     return lower_bound, upper_bound
 
 

--- a/gmaps/bounds.py
+++ b/gmaps/bounds.py
@@ -37,23 +37,27 @@ def longitude_bounds(longitudes):
     for how to calculate the relevant statistics.
     """
     N = float(len(longitudes))
-    radians = [math.radians(longitude) for longitude in longitudes]
-    sum_cos = sum(math.cos(r) for r in radians)
-    sum_cos_sq = sum_cos**2
-    sum_sin = sum(math.sin(r) for r in radians)
-    sum_sin_sq = sum_sin**2
-    mean_radians = math.atan2(sum_sin, sum_cos)
-    mean_degrees = math.degrees(mean_radians)
-    Rsq = (1/N**2) * (sum_cos_sq + sum_sin_sq)
-    standard_deviation = math.sqrt(-math.log(Rsq))
-    extent = 2.0*math.degrees(standard_deviation)
-    if extent > 180.0:
-        # longitudes cover entire map
-        upper_bound = 180.0 - EPSILON
-        lower_bound = -upper_bound
-    else:
-        lower_bound = _normalize_longitude(mean_degrees - extent)
-        upper_bound = _normalize_longitude(mean_degrees + extent)
+    # Change to N > 1 and N == 1 cases
+    if N > 1:
+        radians = [math.radians(longitude) for longitude in longitudes]
+        sum_cos = sum(math.cos(r) for r in radians)
+        sum_cos_sq = sum_cos**2
+        sum_sin = sum(math.sin(r) for r in radians)
+        sum_sin_sq = sum_sin**2
+        mean_radians = math.atan2(sum_sin, sum_cos)
+        mean_degrees = math.degrees(mean_radians)
+        Rsq = (1/N**2) * (sum_cos_sq + sum_sin_sq)
+        standard_deviation = math.sqrt(-math.log(Rsq))
+        extent = 2.0*math.degrees(standard_deviation)
+        if extent > 180.0:
+            # longitudes cover entire map
+            upper_bound = 180.0 - EPSILON
+            lower_bound = -upper_bound
+        else:
+            lower_bound = _normalize_longitude(mean_degrees - extent)
+            upper_bound = _normalize_longitude(mean_degrees + extent)
+    elif N == 1:
+        lower_bound = upper_bound = longitudes[0]
     return lower_bound, upper_bound
 
 

--- a/gmaps/bounds.py
+++ b/gmaps/bounds.py
@@ -12,11 +12,11 @@ def latitude_bounds(latitudes):
     """
     Estimate latitude bound with 2*sample standard deviation
     """
-    N = float(len(latitudes))
-    if N == 1.0:
+    if len(latitudes) == 1:
         lower_bound = latitudes[0] - EPSILON
         upper_bound = latitudes[0] + EPSILON
     else:
+        N = float(len(latitudes))
         mean = sum(latitudes) / N
         sum_squares = sum(
             (latitude-mean)**2 for latitude in latitudes
@@ -40,12 +40,11 @@ def longitude_bounds(longitudes):
     and https://en.wikipedia.org/wiki/Directional_statistics
     for how to calculate the relevant statistics.
     """
-    N = float(len(longitudes))
-    # Change to N == 1 and N > 1 cases
-    if N == 1:
+    if len(longitudes) == 1:
         lower_bound = longitudes[0] - EPSILON
         upper_bound = longitudes[0] + EPSILON
     else:
+        N = float(len(longitudes))
         radians = [math.radians(longitude) for longitude in longitudes]
         sum_cos = sum(math.cos(r) for r in radians)
         sum_cos_sq = sum_cos**2

--- a/gmaps/tests/test_bounds.py
+++ b/gmaps/tests/test_bounds.py
@@ -11,6 +11,12 @@ from ..bounds import (
 
 class LatitudeBounds(unittest.TestCase):
 
+    def test_latitude_bounds_single(self):
+        EPSILON = 1e-5
+        latitudes = [-87.6297]
+        lower, upper = latitude_bounds(latitudes)
+        assert abs(upper - lower) < 2.01*EPSILON
+
     def test_latitude_bounds(self):
         latitudes = [10.0, 15.0, 20.0]
         lower, upper = latitude_bounds(latitudes)
@@ -33,10 +39,10 @@ class LatitudeBounds(unittest.TestCase):
 class LongitudeBounds(unittest.TestCase):
 
     def test_longitude_bounds_single(self):
+        EPSILON = 1e-5
         longitudes = [-87.6297]
         lower, upper = longitude_bounds(longitudes)
-        assert lower == -87.6297
-        assert upper == -87.6297
+        assert abs(upper - lower) < 2.01*EPSILON
 
     def test_longitude_bounds(self):
         longitudes = [10.0, 15.0, 20.0]

--- a/gmaps/tests/test_bounds.py
+++ b/gmaps/tests/test_bounds.py
@@ -32,6 +32,12 @@ class LatitudeBounds(unittest.TestCase):
 
 class LongitudeBounds(unittest.TestCase):
 
+    def test_longitude_bounds_single(self):
+        longitudes = [-87.6297]
+        lower, upper = longitude_bounds(longitudes)
+        assert lower == -87.6297
+        assert upper == -87.6297
+
     def test_longitude_bounds(self):
         longitudes = [10.0, 15.0, 20.0]
         lower, upper = longitude_bounds(longitudes)


### PR DESCRIPTION
Broke up the functionality in location_bounds to a case for N > 1 and a case for N ==1.  N > 1 is the original code (subtracting the case for N == 1).  For the N == 1 case, both the lower and upper bounds would be the same as the location (longitude) passed.