### PR TITLE
Transit layer

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,6 +19,8 @@ Figures and layers
 
 .. autofunction:: gmaps.bicycling_layer
 
+.. autofunction:: gmaps.transit_layer
+
 Utility functions
 -----------------
 
@@ -54,6 +56,8 @@ Low level widgets
 .. autoclass:: gmaps.Directions
 
 .. autoclass:: gmaps.Bicycling
+
+.. autoclass:: gmaps.Transit
 
 Datasets
 --------

--- a/gmaps/__init__.py
+++ b/gmaps/__init__.py
@@ -7,6 +7,7 @@ from .heatmap import *  # noqa
 from .directions import *  # noqa
 from .geojson_layer import *  # noqa
 from .bicycling import *  # noqa
+from .transit import *  # noqa
 
 
 def _jupyter_nbextension_paths():

--- a/gmaps/bicycling.py
+++ b/gmaps/bicycling.py
@@ -31,6 +31,9 @@ def bicycling_layer():
     Adds cycle routes and decreases the weight of main routes
     on the map.
 
+    :returns:
+        A :class:`gmaps.Bicycling` widget.
+
     :Examples:
 
     >>> fig = gmaps.figure()

--- a/gmaps/figure.py
+++ b/gmaps/figure.py
@@ -55,6 +55,12 @@ class Figure(widgets.DOMWidget):
 
             :func:`gmaps.directions_layer`
                 Create a layer with directions
+
+            :func:`gmaps.bicycling_layer`
+                Create a layer showing cycle routes
+
+            :func:`gmaps.transit_layer`
+                Create a layer showing public transport
         """
         self._map.add_layer(layer)
 

--- a/gmaps/transit.py
+++ b/gmaps/transit.py
@@ -1,0 +1,10 @@
+import ipywidgets as widgets
+from traitlets import Unicode
+
+
+class Transit(widgets.Widget):
+    _view_name = Unicode('TransitLayerView').tag(sync=True)
+    _view_module = Unicode('jupyter-gmaps').tag(sync=True)
+    _model_name = Unicode('TransitLayerModel').tag(sync=True)
+    _model_module = Unicode('jupyter-gmaps').tag(sync=True)
+    has_bounds = False

--- a/gmaps/transit.py
+++ b/gmaps/transit.py
@@ -3,6 +3,27 @@ from traitlets import Unicode
 
 
 class Transit(widgets.Widget):
+    """
+    Transit layer.
+
+    Add this to a :class:`gmaps.Map` or a :class:`gmaps.Figure` 
+    instance to add transit (public transport) information. 
+    This only affects regions for which Google has 
+    `transit information
+    <https://www.google.com/landing/transit/cities/index.html>`_.
+
+    You should not instantiate this directly. Instead,
+    use the :func:`gmaps.transit_layer` factory function.
+
+    :Examples:
+
+    ::
+
+        # map centered on London
+        >>> fig = gmaps.figure(center=(51.5, -0.2), zoom_level=11)
+        >>> fig.add_layer(gmaps.transit_layer())
+        >>> fig
+    """
     _view_name = Unicode('TransitLayerView').tag(sync=True)
     _view_module = Unicode('jupyter-gmaps').tag(sync=True)
     _model_name = Unicode('TransitLayerModel').tag(sync=True)

--- a/gmaps/transit.py
+++ b/gmaps/transit.py
@@ -40,6 +40,9 @@ def transit_layer():
     `public transport information
     <https://www.google.com/landing/transit/cities/index.html>`_.
 
+    :returns:
+        A :class:`gmaps.Transit` widget.
+
     :Examples:
 
     ::

--- a/gmaps/transit.py
+++ b/gmaps/transit.py
@@ -6,9 +6,9 @@ class Transit(widgets.Widget):
     """
     Transit layer.
 
-    Add this to a :class:`gmaps.Map` or a :class:`gmaps.Figure` 
-    instance to add transit (public transport) information. 
-    This only affects regions for which Google has 
+    Add this to a :class:`gmaps.Map` or a :class:`gmaps.Figure`
+    instance to add transit (public transport) information.
+    This only affects regions for which Google has
     `transit information
     <https://www.google.com/landing/transit/cities/index.html>`_.
 

--- a/gmaps/transit.py
+++ b/gmaps/transit.py
@@ -8,3 +8,24 @@ class Transit(widgets.Widget):
     _model_name = Unicode('TransitLayerModel').tag(sync=True)
     _model_module = Unicode('jupyter-gmaps').tag(sync=True)
     has_bounds = False
+
+
+def transit_layer():
+    """
+    Transit layer.
+
+    Adds information about public transport lines to the
+    map. This only affects region for which Google has
+    `public transport information
+    <https://www.google.com/landing/transit/cities/index.html>`_.
+
+    :Examples:
+
+    ::
+
+        # map centered on London
+        >>> fig = gmaps.figure(center=(51.5, -0.2), zoom_level=11)
+        >>> fig.add_layer(gmaps.transit_layer())
+        >>> fig
+    """
+    return Transit()

--- a/js/src/Bicycling.js
+++ b/js/src/Bicycling.js
@@ -6,8 +6,8 @@ export class BicyclingLayerModel extends GMapsLayerModel {
     defaults() {
         return {
             ...super.defaults(),
-            _view_name: 'BicyclingLayerModel',
-            _model_name: 'BicyclingLayerView'
+            _view_name: 'BicyclingLayerView',
+            _model_name: 'BicyclingLayerModel'
         }
     }
 }

--- a/js/src/Transit.js
+++ b/js/src/Transit.js
@@ -1,0 +1,25 @@
+import GoogleMapsLoader from 'google-maps';
+
+import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';
+
+export class TransitLayerModel extends GMapsLayerModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            _view_name: 'TransitLayerView',
+            _model_name: 'TransitLayerModel'
+        }
+    }
+}
+
+export class TransitLayerView extends GMapsLayerView {
+    render() {
+        GoogleMapsLoader.load((google) => {
+            this.transitLayer = new google.maps.TransitLayer();
+        });
+    }
+
+    addToMapView(mapView) {
+        this.transitLayer.setMap(mapView.map);
+    }
+}

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -19,5 +19,6 @@ export * from './GeoJson';
 export * from './Directions';
 export * from './ErrorsBox';
 export * from './Bicycling';
+export * from './Transit';
 
 export { version } from '../package.json';


### PR DESCRIPTION
This PR lets users add a [transit layer](https://developers.google.com/maps/documentation/javascript/trafficlayer) to the base map.

<img width="1129" alt="screen shot 2017-07-31 at 07 49 15" src="https://user-images.githubusercontent.com/1392879/28766272-c1d16ad2-75c6-11e7-8820-62368c00a62d.png">

This is what's left to do:

 - [x] docstring for widget
 - [ ] ~~amend tutorial (now or after adding the traffic layer?)~~
 - [x] document return types for factory functions