### PR TITLE
Migrate to ipywidgets 7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ Installing `gmaps` with `pip`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you do not use conda, you can install `gmaps` with pip. The current version
-of `gmaps` is only tested with *IPython 4.2* or later and *ipywidgets 6.0.0* or
+of `gmaps` is only tested with *IPython 4.3* or later and *ipywidgets 7.0.0* or
 later. To upgrade to the latest versions, use::
 
     $ pip install -U jupyter

--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -22,7 +22,7 @@ You can export maps to HTML using the infrastructure provided by `ipywidgets`. I
 .. code-block:: html
 
   <!-- Script tags that need to go into the head of the document -->
-  <script src="https://unpkg.com/jupyter-js-widgets@~2.1.4/dist/embed.js"></script>
+  <script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed.js"></script>
 
   <script type="application/vnd.jupyter.widget-state+json">
       // State of the widgets
@@ -75,7 +75,7 @@ Thus, a valid HTML document containing a single map would look like this (the AP
            <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
            <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 
-           <script src="https://unpkg.com/jupyter-js-widgets@~2.1.4/dist/embed.js"></script>
+           <script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed.js"></script>
            <script type="application/vnd.jupyter.widget-state+json">
            {
                "version_major": 1,

--- a/gmaps/_version.py
+++ b/gmaps/_version.py
@@ -2,7 +2,7 @@
 # This file is generated programatically.
 
 # Version of the Python package
-__version__ = '0.6.0-alpha2'
+__version__ = '0.6.0-alpha4'
 
 # Version of the JS client. This must match the version field in package.json.
-CLIENT_VERSION = '0.6.0-alpha2'
+CLIENT_VERSION = '0.6.0-alpha4'

--- a/gmaps/_version.py
+++ b/gmaps/_version.py
@@ -3,3 +3,6 @@
 
 # Version of the Python package
 __version__ = '0.6.0-alpha1'
+
+# Version of the JS client. This must match the version field in package.json
+CLIENT_VERSION = '0.6.0-alpha1'

--- a/gmaps/_version.py
+++ b/gmaps/_version.py
@@ -2,7 +2,7 @@
 # This file is generated programatically.
 
 # Version of the Python package
-__version__ = '0.6.0-alpha1'
+__version__ = '0.6.0-alpha2'
 
-# Version of the JS client. This must match the version field in package.json
-CLIENT_VERSION = '0.6.0-alpha1'
+# Version of the JS client. This must match the version field in package.json.
+CLIENT_VERSION = '0.6.0-alpha2'

--- a/gmaps/_version.py
+++ b/gmaps/_version.py
@@ -1,3 +1,5 @@
 
 # This file is generated programatically.
-__version__ = '0.5.5-dev'
+
+# Version of the Python package
+__version__ = '0.6.0-alpha1'

--- a/gmaps/bicycling.py
+++ b/gmaps/bicycling.py
@@ -1,8 +1,10 @@
 import ipywidgets as widgets
 from traitlets import Unicode
 
+from .maps import GMapsWidgetMixin
 
-class Bicycling(widgets.Widget):
+
+class Bicycling(GMapsWidgetMixin, widgets.Widget):
     """
     Bicycling layer.
 
@@ -18,9 +20,7 @@ class Bicycling(widgets.Widget):
     >>> fig.add_layer(gmaps.bicycling_layer())
     """
     _view_name = Unicode('BicyclingLayerView').tag(sync=True)
-    _view_module = Unicode('jupyter-gmaps').tag(sync=True)
     _model_name = Unicode('BicyclingLayerModel').tag(sync=True)
-    _model_module = Unicode('jupyter-gmaps').tag(sync=True)
     has_bounds = False
 
 

--- a/gmaps/directions.py
+++ b/gmaps/directions.py
@@ -5,6 +5,7 @@ from traitlets import Bool, Unicode, CUnicode, List, Enum, observe, validate
 
 from . import geotraitlets
 from .locations import locations_to_list
+from .maps import GMapsWidgetMixin
 
 
 ALLOWED_TRAVEL_MODES = {'BICYCLING', 'DRIVING', 'TRANSIT', 'WALKING'}
@@ -15,7 +16,7 @@ class DirectionsServiceException(RuntimeError):
     pass
 
 
-class Directions(widgets.Widget):
+class Directions(GMapsWidgetMixin, widgets.Widget):
     """
     Directions layer.
 

--- a/gmaps/errors_box.py
+++ b/gmaps/errors_box.py
@@ -3,13 +3,13 @@ import ipywidgets as widgets
 
 from traitlets import Unicode, List
 
+from .maps import GMapsWidgetMixin
 
-class ErrorsBox(widgets.DOMWidget):
+
+class ErrorsBox(GMapsWidgetMixin, widgets.DOMWidget):
     """
     Box to hold any JS errors that occur
     """
     _view_name = Unicode("ErrorsBoxView").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
     _model_name = Unicode("ErrorsBoxModel").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     errors = List(trait=Unicode).tag(sync=True)

--- a/gmaps/figure.py
+++ b/gmaps/figure.py
@@ -3,14 +3,14 @@ import ipywidgets as widgets
 
 from traitlets import Unicode, Instance
 
-from .maps import Map, InitialViewport
+from .maps import Map, InitialViewport, GMapsWidgetMixin
 from .toolbar import Toolbar
 from .errors_box import ErrorsBox
 
 __all__ = ["Figure", "figure"]
 
 
-class Figure(widgets.DOMWidget):
+class Figure(GMapsWidgetMixin, widgets.DOMWidget):
     """
     Figure widget
 
@@ -19,9 +19,7 @@ class Figure(widgets.DOMWidget):
     factory method.
     """
     _view_name = Unicode("FigureView").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
     _model_name = Unicode("FigureModel").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     _toolbar = Instance(Toolbar, allow_none=True, default=None).tag(
         sync=True, **widgets.widget_serialization)
     _errors_box = Instance(ErrorsBox, allow_none=True, default=None).tag(

--- a/gmaps/geojson_layer.py
+++ b/gmaps/geojson_layer.py
@@ -11,6 +11,7 @@ from . import geotraitlets
 from . import bounds
 from .options import (
     merge_option_dicts, broadcast_if_atomic, broadcast_if_color_atomic)
+from .maps import GMapsWidgetMixin
 
 __all__ = ["GeoJson", "geojson_layer", "GeoJsonFeature", "InvalidGeoJson"]
 
@@ -19,7 +20,7 @@ class InvalidGeoJson(Exception):
     pass
 
 
-class GeoJsonFeature(widgets.Widget):
+class GeoJsonFeature(GMapsWidgetMixin, widgets.Widget):
     """
     Widget for a single GeoJSON feature.
 
@@ -28,8 +29,6 @@ class GeoJsonFeature(widgets.Widget):
     """
     _view_name = Unicode("GeoJsonFeatureView").tag(sync=True)
     _model_name = Unicode("GeoJsonFeatureModel").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     feature = Dict().tag(sync=True)
     has_bounds = False
     fill_color = geotraitlets.ColorAlpha(
@@ -46,7 +45,7 @@ class GeoJsonFeature(widgets.Widget):
         return geojson.utils.coords(self.feature)
 
 
-class GeoJson(widgets.Widget):
+class GeoJson(GMapsWidgetMixin, widgets.Widget):
     """
     Widget for a collection of GeoJSON features.
 
@@ -58,8 +57,6 @@ class GeoJson(widgets.Widget):
     """
     _view_name = Unicode("GeoJsonLayerView").tag(sync=True)
     _model_name = Unicode("GeoJsonLayerModel").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     has_bounds = True
     data_bounds = List().tag(sync=True)
     features = List().tag(sync=True, **widgets.widget_serialization)

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -7,6 +7,7 @@ from traitlets import (
 from . import bounds
 from .locations import locations_to_list, locations_docstring
 from . import geotraitlets
+from .maps import GMapsWidgetMixin
 
 
 _heatmap_options_docstring = """
@@ -77,7 +78,7 @@ class _HeatmapOptionsMixin(HasTraits):
         return bounds.longitude_bounds(longitudes)
 
 
-class Heatmap(widgets.Widget, _HeatmapOptionsMixin):
+class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     __doc__ = """
     Heatmap layer.
 
@@ -108,9 +109,7 @@ class Heatmap(widgets.Widget, _HeatmapOptionsMixin):
     """ + _heatmap_options_docstring
     has_bounds = True
     _view_name = Unicode("SimpleHeatmapLayerView").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
     _model_name = Unicode("SimpleHeatmapLayerModel").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
 
     data = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
@@ -129,7 +128,7 @@ class Heatmap(widgets.Widget, _HeatmapOptionsMixin):
         self.set_bounds(data)
 
 
-class WeightedHeatmap(widgets.Widget, _HeatmapOptionsMixin):
+class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     __doc__ = """
     Heatmap with weighted points.
 
@@ -161,9 +160,7 @@ class WeightedHeatmap(widgets.Widget, _HeatmapOptionsMixin):
     """ + _heatmap_options_docstring
     has_bounds = True
     _view_name = Unicode("WeightedHeatmapLayerView").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
     _model_name = Unicode("WeightedHeatmapLayerModel").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
 
     data = List().tag(sync=True)
     data_bounds = List().tag(sync=True)

--- a/gmaps/maps.py
+++ b/gmaps/maps.py
@@ -5,6 +5,7 @@ from traitlets import (Unicode, default, List, Tuple, Instance,
 
 from .bounds import merge_longitude_bounds
 from .geotraitlets import Point, ZoomLevel
+from ._version import CLIENT_VERSION
 
 DEFAULT_CENTER = (46.2, 6.1)
 DEFAULT_BOUNDS = [(46.2, 6.1), (47.2, 7.1)]
@@ -31,6 +32,16 @@ class ConfigurationMixin(HasTraits):
     @default("configuration")
     def _config_default(self):
         return _default_configuration
+
+
+class GMapsWidgetMixin(HasTraits):
+    """
+    Traitlets that are constant across all of gmaps
+    """
+    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
+    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
+    _model_module_version = Unicode(CLIENT_VERSION).tag(sync=True)
+    _view_module_version = Unicode(CLIENT_VERSION).tag(sync=True)
 
 
 class InitialViewport(Union):
@@ -108,7 +119,7 @@ def _serialize_viewport(viewport, manager):
     return payload
 
 
-class Map(widgets.DOMWidget, ConfigurationMixin):
+class Map(ConfigurationMixin, GMapsWidgetMixin, widgets.DOMWidget):
     """
     Base map class
 
@@ -138,9 +149,7 @@ class Map(widgets.DOMWidget, ConfigurationMixin):
     >>> m = gmaps.figure(initial_viewport=viewport)
     """
     _view_name = Unicode("PlainmapView").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
     _model_name = Unicode("PlainmapModel").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     layers = Tuple(trait=Instance(widgets.Widget)).tag(
         sync=True, **widgets.widget_serialization)
     data_bounds = List(DEFAULT_BOUNDS).tag(sync=True)

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -7,7 +7,7 @@ from traitlets import (
 import gmaps.geotraitlets as geotraitlets
 import gmaps.bounds as bounds
 
-from .maps import DEFAULT_CENTER
+from .maps import DEFAULT_CENTER, GMapsWidgetMixin
 from .locations import locations_to_list
 from .options import merge_option_dicts, is_atomic, is_color_atomic
 
@@ -15,15 +15,13 @@ __all__ = ["Symbol", "Marker", "Markers", "marker_layer", "symbol_layer"]
 
 
 class _BaseMarkerMixin(HasTraits):
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
     location = geotraitlets.Point(DEFAULT_CENTER).tag(sync=True)
     hover_text = Unicode("").tag(sync=True)
     display_info_box = Bool(False).tag(sync=True)
     info_box_content = Unicode("").tag(sync=True)
 
 
-class Symbol(_BaseMarkerMixin, widgets.Widget):
+class Symbol(GMapsWidgetMixin, _BaseMarkerMixin, widgets.Widget):
     """
     Class representing a single symbol.
 
@@ -48,7 +46,7 @@ class Symbol(_BaseMarkerMixin, widgets.Widget):
     ).tag(sync=True)
 
 
-class Marker(_BaseMarkerMixin, widgets.Widget):
+class Marker(GMapsWidgetMixin, _BaseMarkerMixin, widgets.Widget):
     """
     Class representing a marker.
 
@@ -60,15 +58,13 @@ class Marker(_BaseMarkerMixin, widgets.Widget):
     label = Unicode("").tag(sync=True)
 
 
-class Markers(widgets.Widget):
+class Markers(GMapsWidgetMixin, widgets.Widget):
     """
     A collection of markers or symbols.
     """
     has_bounds = True
     _view_name = Unicode("MarkerLayerView").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
     _model_name = Unicode("MarkerLayerModel").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)
 
     markers = List(minlen=1).tag(sync=True,  **widgets.widget_serialization)
     data_bounds = List().tag(sync=True)

--- a/gmaps/toolbar.py
+++ b/gmaps/toolbar.py
@@ -3,9 +3,9 @@ import ipywidgets as widgets
 
 from traitlets import Unicode
 
+from .maps import GMapsWidgetMixin
 
-class Toolbar(widgets.DOMWidget):
+
+class Toolbar(GMapsWidgetMixin, widgets.DOMWidget):
     _view_name = Unicode("ToolbarView").tag(sync=True)
-    _view_module = Unicode("jupyter-gmaps").tag(sync=True)
     _model_name = Unicode("ToolbarModel").tag(sync=True)
-    _model_module = Unicode("jupyter-gmaps").tag(sync=True)

--- a/gmaps/transit.py
+++ b/gmaps/transit.py
@@ -1,8 +1,10 @@
 import ipywidgets as widgets
 from traitlets import Unicode
 
+from .maps import GMapsWidgetMixin
 
-class Transit(widgets.Widget):
+
+class Transit(GMapsWidgetMixin, widgets.Widget):
     """
     Transit layer.
 
@@ -25,9 +27,7 @@ class Transit(widgets.Widget):
         >>> fig
     """
     _view_name = Unicode('TransitLayerView').tag(sync=True)
-    _view_module = Unicode('jupyter-gmaps').tag(sync=True)
     _model_name = Unicode('TransitLayerModel').tag(sync=True)
-    _model_module = Unicode('jupyter-gmaps').tag(sync=True)
     has_bounds = False
 
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-gmaps",
-  "version": "0.5.4",
+  "version": "0.6.0-alpha1",
   "description": "Google maps plugin for Jupyter notebooks",
   "author": "Pascal Bugnion",
   "main": "src/index.js",

--- a/js/package.json
+++ b/js/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "google-maps": "^3.2.1",
-    "@jupyter-widgets/base": "^0.6.7",
-    "@jupyter-widgets/controls": "^0.6.7",
+    "@jupyter-widgets/base": "^1.0.0",
+    "@jupyter-widgets/controls": "^1.0.0",
     "underscore": "^1.8.3"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-gmaps",
-  "version": "0.6.0-alpha2",
+  "version": "0.6.0-alpha3",
   "description": "Google maps plugin for Jupyter notebooks",
   "author": "Pascal Bugnion",
   "main": "src/index.js",
@@ -39,6 +39,7 @@
     "google-maps": "^3.2.1",
     "@jupyter-widgets/base": "^1.0.0",
     "@jupyter-widgets/controls": "^1.0.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "jquery": "^3.2.1"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "google-maps": "^3.2.1",
-    "jupyter-js-widgets": "3.0.0-alpha.2",
+    "@jupyter-widgets/base": "^0.6.7",
+    "@jupyter-widgets/controls": "^0.6.7",
     "underscore": "^1.8.3"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-gmaps",
-  "version": "0.6.0-alpha1",
+  "version": "0.6.0-alpha2",
   "description": "Google maps plugin for Jupyter notebooks",
   "author": "Pascal Bugnion",
   "main": "src/index.js",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-gmaps",
-  "version": "0.6.0-alpha3",
+  "version": "0.6.0-alpha4",
   "description": "Google maps plugin for Jupyter notebooks",
   "author": "Pascal Bugnion",
   "main": "src/index.js",

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -1,5 +1,7 @@
 import * as widgets from '@jupyter-widgets/base';
 
+import $ from 'jquery';
+
 export class ErrorsBoxModel extends widgets.DOMWidgetModel {
     defaults() {
         return {

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -1,4 +1,4 @@
-import widgets from '@jupyter-widgets/base';
+import * as widgets from '@jupyter-widgets/base';
 
 export class ErrorsBoxModel extends widgets.DOMWidgetModel {
     defaults() {

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -1,4 +1,4 @@
-import widgets from 'jupyter-js-widgets';
+import widgets from '@jupyter-widgets/base';
 
 export class ErrorsBoxModel extends widgets.DOMWidgetModel {
     defaults() {

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -1,9 +1,10 @@
 
 import _ from 'underscore';
 
-import widgets from 'jupyter-js-widgets';
+import widgets from '@jupyter-widgets/base';
+import { VBoxModel, VBoxView } from '@jupyter-widgets/controls';
 
-export class FigureModel extends widgets.VBoxModel {
+export class FigureModel extends VBoxModel {
     defaults() {
         return {
             ...super.defaults(),
@@ -28,7 +29,7 @@ export class FigureModel extends widgets.VBoxModel {
     }
 }
 
-export class FigureView extends widgets.VBoxView {
+export class FigureView extends VBoxView {
     initialize(parameters) {
         super.initialize(parameters)
         const toolbarModel = this.model.get("_toolbar");

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -1,7 +1,7 @@
 
 import _ from 'underscore';
 
-import widgets from '@jupyter-widgets/base';
+import * as widgets from '@jupyter-widgets/base';
 import { VBoxModel, VBoxView } from '@jupyter-widgets/controls';
 
 export class FigureModel extends VBoxModel {

--- a/js/src/GMapsLayer.js
+++ b/js/src/GMapsLayer.js
@@ -1,4 +1,4 @@
-import widgets from 'jupyter-js-widgets';
+import widgets from '@jupyter-widgets/base';
 
 export class GMapsLayerView extends widgets.WidgetView {
     initialize(parameters) {

--- a/js/src/GMapsLayer.js
+++ b/js/src/GMapsLayer.js
@@ -1,4 +1,4 @@
-import widgets from '@jupyter-widgets/base';
+import * as widgets from '@jupyter-widgets/base';
 
 export class GMapsLayerView extends widgets.WidgetView {
     initialize(parameters) {

--- a/js/src/GeoJson.js
+++ b/js/src/GeoJson.js
@@ -1,4 +1,4 @@
-import widgets from 'jupyter-js-widgets';
+import widgets from '@jupyter-widgets/base';
 import GoogleMapsLoader from 'google-maps';
 
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';

--- a/js/src/GeoJson.js
+++ b/js/src/GeoJson.js
@@ -1,4 +1,4 @@
-import widgets from '@jupyter-widgets/base';
+import * as widgets from '@jupyter-widgets/base';
 import GoogleMapsLoader from 'google-maps';
 
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -1,4 +1,4 @@
-import widgets from '@jupyter-widgets/base'
+import * as widgets from '@jupyter-widgets/base'
 import _ from 'underscore'
 
 import GoogleMapsLoader from 'google-maps'

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -1,4 +1,4 @@
-import widgets from 'jupyter-js-widgets'
+import widgets from '@jupyter-widgets/base'
 import _ from 'underscore'
 
 import GoogleMapsLoader from 'google-maps'

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -1,5 +1,5 @@
 
-import widgets from 'jupyter-js-widgets';
+import widgets from '@jupyter-widgets/base';
 
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';
 

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -1,5 +1,5 @@
 
-import widgets from '@jupyter-widgets/base';
+import * as widgets from '@jupyter-widgets/base';
 
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';
 

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -1,4 +1,5 @@
 import * as widgets from '@jupyter-widgets/base'
+import $ from 'jquery'
 
 export class ToolbarModel extends widgets.DOMWidgetModel {
     defaults() {

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -1,4 +1,4 @@
-import widgets from '@jupyter-widgets/base'
+import * as widgets from '@jupyter-widgets/base'
 
 export class ToolbarModel extends widgets.DOMWidgetModel {
     defaults() {

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -1,4 +1,4 @@
-import widgets from 'jupyter-js-widgets'
+import widgets from '@jupyter-widgets/base'
 
 export class ToolbarModel extends widgets.DOMWidgetModel {
     defaults() {

--- a/js/src/extension.js
+++ b/js/src/extension.js
@@ -7,8 +7,7 @@ if (window.require) {
     window.require.config({
         map: {
             "*" : {
-                "jupyter-gmaps": "nbextensions/jupyter-gmaps/index",
-                "jupyter-js-widgets": "nbextensions/jupyter-js-widgets/extension"
+                "jupyter-gmaps": "nbextensions/jupyter-gmaps/index"
             }
         }
     });

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['@jupyter-widgets/base', '@jupyter-widgets/controls']
     },
     {// Embeddable jupyter-gmaps bundle
      //
@@ -69,6 +69,6 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['@jupyter-widgets/base', '@jupyter-widgets/controls']
     }
 ];

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
 ipython>=5.3.0
-ipywidgets>=6.0.0
+ipywidgets>=7.0.0b6
 traitlets>=4.3.0
 geojson>=1.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ six
 ipython>=5.3.0
 ipywidgets>=7.0.0
 traitlets>=4.3.0
-geojson>=1.3.4
+geojson>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
 ipython>=5.3.0
-ipywidgets>=7.0.0b6
+ipywidgets>=7.0.0
 traitlets>=4.3.0
 geojson>=1.3.4

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup_args = {
     ],
     'install_requires': [
         'ipython>=5.3.0',
-        'ipywidgets>=7.0.0b6',
+        'ipywidgets>=7.0.0',
         'traitlets>=4.3.0',
         'geojson>=1.3.4',
         'six'

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup_args = {
         'ipython>=5.3.0',
         'ipywidgets>=7.0.0',
         'traitlets>=4.3.0',
-        'geojson>=1.3.4',
+        'geojson>=2.0.0',
         'six'
     ],
     'packages': find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup_args = {
     ],
     'install_requires': [
         'ipython>=5.3.0',
-        'ipywidgets>=6.0.0',
+        'ipywidgets>=7.0.0b6',
         'traitlets>=4.3.0',
         'geojson>=1.3.4',
         'six'

--- a/tasks.py
+++ b/tasks.py
@@ -13,7 +13,12 @@ import semver
 
 VERSION_TEMPLATE = '''
 # This file is generated programatically.
+
+# Version of the Python package
 __version__ = '{version_string}'
+
+# Version of the JS client. This must match the version field in package.json.
+CLIENT_VERSION = '{version_string}'
 '''
 
 RELEASE_NOTES_TEMPLATE = '''# Write the release notes here
@@ -98,6 +103,7 @@ def postrelease(ctx, version):
     run('git push origin master --tags')
     new_version = semver.bump_patch(version) + '-dev'
     set_pyversion(new_version)
+    set_jsversion(new_version)
     run('git add gmaps/_version.py')
     run('git commit -m "Back to dev"')
     run('git push origin master')


### PR DESCRIPTION
This starts the migration to jupyter-widgets 7.0.0 and geojson 2.0.0. This PR is now available as version `0.6.0-alpha2`.

```
pip install gmaps==0.6.0-alpha2
jupyter nbextension enable --py --sys-prefix gmaps
```