### PR TITLE
Allow exporting bicycling and transit layers to PNG

### DIFF
--- a/js/src/Bicycling.js
+++ b/js/src/Bicycling.js
@@ -13,6 +13,12 @@ export class BicyclingLayerModel extends GMapsLayerModel {
 }
 
 export class BicyclingLayerView extends GMapsLayerView {
+
+    constructor(options) {
+        super(options);
+        this.canDownloadAsPng = true;
+    }
+
     render() {
         GoogleMapsLoader.load((google) => {
             this.bicyclingLayer = new google.maps.BicyclingLayer();

--- a/js/src/Transit.js
+++ b/js/src/Transit.js
@@ -13,6 +13,12 @@ export class TransitLayerModel extends GMapsLayerModel {
 }
 
 export class TransitLayerView extends GMapsLayerView {
+
+    constructor(options) {
+        super(options);
+        this.canDownloadAsPng = true;
+    }
+
     render() {
         GoogleMapsLoader.load((google) => {
             this.transitLayer = new google.maps.TransitLayer();


### PR DESCRIPTION
Prior to this commit, the bicycling and transit layers could not be exported to PNG because they were not explicitly marked as exportable. Since html2canvas seems to work reasonably with these, there is no good reason not to mark them as exportable.