### PR TITLE
Include the version number in JavaScript

### DIFF
--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -1,4 +1,5 @@
 import * as widgets from '@jupyter-widgets/base';
+import { defaultAttributes } from './defaults'
 
 import $ from 'jquery';
 
@@ -6,10 +7,9 @@ export class ErrorsBoxModel extends widgets.DOMWidgetModel {
     defaults() {
         return {
             ...super.defaults(),
+            ...defaultAttributes,
             _model_name: 'ErrorsBoxModel',
             _view_name: 'ErrorsBoxView',
-            _model_module: 'jupyter-gmaps',
-            _view_module: 'jupyter-gmaps',
             errors: []
         };
     }

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -3,15 +3,15 @@ import _ from 'underscore';
 
 import * as widgets from '@jupyter-widgets/base';
 import { VBoxModel, VBoxView } from '@jupyter-widgets/controls';
+import { defaultAttributes } from './defaults';
 
 export class FigureModel extends VBoxModel {
     defaults() {
         return {
             ...super.defaults(),
+            ...defaultAttributes,
             _model_name: "FigureModel",
             _view_name: "FigureView",
-            _model_module: "jupyter-gmaps",
-            _view_module: "jupyter-gmaps",
             children: [],
             box_style: '',
             _map: undefined,

--- a/js/src/GMapsLayer.js
+++ b/js/src/GMapsLayer.js
@@ -1,4 +1,5 @@
 import * as widgets from '@jupyter-widgets/base';
+import { defaultAttributes } from './defaults';
 
 export class GMapsLayerView extends widgets.WidgetView {
     initialize(parameters) {
@@ -12,10 +13,9 @@ export class GMapsLayerModel extends widgets.WidgetModel {
     defaults() {
         return {
             ...super.defaults(),
+            ...defaultAttributes,
             _view_name : 'GMapsLayerView',
             _model_name : 'GMapsLayerModel',
-            _view_module : 'jupyter-gmaps',
-            _model_module : 'jupyter-gmaps'
         }
     }
 }

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -5,6 +5,7 @@ import GoogleMapsLoader from 'google-maps'
 
 import { downloadElementAsPng } from './services/downloadElement'
 import { GMapsLayerView, GMapsLayerModel } from './GMapsLayer';
+import { defaultAttributes } from './defaults'
 
 function needReloadGoogleMaps(configuration) {
     return GoogleMapsLoader.KEY !== configuration["api_key"];
@@ -145,10 +146,9 @@ export class PlainmapModel extends widgets.DOMWidgetModel {
     defaults() {
         return {
             ...super.defaults(),
+            ...defaultAttributes,
             _view_name: "PlainmapView",
             _model_name: "PlainmapModel",
-            _view_module : 'jupyter-gmaps',
-            _model_module : 'jupyter-gmaps',
             width: "600px",
             height: "400px",
             data_bounds: null,

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -1,14 +1,15 @@
 import * as widgets from '@jupyter-widgets/base'
 import $ from 'jquery'
 
+import { defaultAttributes } from './defaults'
+
 export class ToolbarModel extends widgets.DOMWidgetModel {
     defaults() {
         return {
             ...super.defaults(),
+            ...defaultAttributes,
             _model_name: "ToolbarModel",
             _view_name: "ToolbarView",
-            _model_module: "jupyter-gmaps",
-            _view_module: "jupyter-gmaps",
         }
     }
 };

--- a/js/src/defaults.js
+++ b/js/src/defaults.js
@@ -1,0 +1,8 @@
+import { version } from '../package.json'
+
+export const defaultAttributes = {
+    _view_module : 'jupyter-gmaps',
+    _model_module : 'jupyter-gmaps',
+    _view_module_version: version,
+    _model_module_version: version
+}

--- a/js/src/defaults.js
+++ b/js/src/defaults.js
@@ -1,8 +1,8 @@
 import { version } from '../package.json'
 
 export const defaultAttributes = {
-    _view_module : 'jupyter-gmaps',
-    _model_module : 'jupyter-gmaps',
+    _view_module: 'jupyter-gmaps',
+    _model_module: 'jupyter-gmaps',
     _view_module_version: version,
     _model_module_version: version
 }


### PR DESCRIPTION
This helps with exports when the defaults are not included.