### PR TITLE
Flake8 fixes

### DIFF
--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -83,14 +83,14 @@ class HeatmapLayer(unittest.TestCase):
 class TestHeatmapOptionsMixin(unittest.TestCase):
 
     def test_gradient_default_none(self):
-        l = _HeatmapOptionsMixin()
-        assert l.gradient is None
+        layer = _HeatmapOptionsMixin()
+        assert layer.gradient is None
 
     def test_gradient_default_values(self):
-        l = _HeatmapOptionsMixin(gradient=["blue", "red"])
-        assert l.gradient == ["blue", "red"]
+        layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
+        assert layer.gradient == ["blue", "red"]
 
     def test_gradient_set_none(self):
-        l = _HeatmapOptionsMixin(gradient=["blue", "red"])
-        l.gradient = None
-        assert l.gradient is None
+        layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
+        layer.gradient = None
+        assert layer.gradient is None

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest
-flake8
+pytest==3.2.3
+flake8==3.5.0
 numpy
 pandas


### PR DESCRIPTION
A merge to master broke the build because of an upgrade in Flake8. This fixes the flake8 problem and hardcodes the version dependency for flake8 so we avoid future regressions.