### PR TITLE
Fix marker clickable state

### DIFF
--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -53,7 +53,6 @@ def _resolve_info_box_kwargs(**kwargs):
     return kwargs
 
 
-
 class MarkerOptions(HasTraits):
     __doc__ = """
     Style options for a marker

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -124,6 +124,11 @@ class Symbol(GMapsWidgetMixin, _BaseMarkerMixin, widgets.Widget):
         default_value=4, allow_none=True, min=1
     ).tag(sync=True)
 
+    def __init__(self, location, **kwargs):
+        kwargs = _resolve_info_box_kwargs(**kwargs)
+        kwargs['location'] = location
+        super(Symbol, self).__init__(**kwargs)
+
 
 class Marker(GMapsWidgetMixin, _BaseMarkerMixin, widgets.Widget):
     __doc__ = """

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -41,6 +41,19 @@ _marker_options_docstring = """
 """
 
 
+def _resolve_info_box_kwargs(**kwargs):
+    if kwargs.get('display_info_box') is None:
+        # Not explicitly specified: infer from info_box_content
+        is_content_empty = kwargs.get('info_box_content') is None
+        if is_content_empty:
+            kwargs['display_info_box'] = False
+            kwargs['info_box_content'] = ''
+        else:
+            kwargs['display_info_box'] = True
+    return kwargs
+
+
+
 class MarkerOptions(HasTraits):
     __doc__ = """
     Style options for a marker
@@ -51,14 +64,7 @@ class MarkerOptions(HasTraits):
     label = Unicode("").tag(sync=True)
 
     def __init__(self, **kwargs):
-        if kwargs.get('display_info_box') is None:
-            # Not explicitly specified: infer from info_box_content
-            is_content_empty = kwargs.get('info_box_content') is None
-            if is_content_empty:
-                kwargs['display_info_box'] = False
-                kwargs['info_box_content'] = ''
-            else:
-                kwargs['display_info_box'] = True
+        kwargs = _resolve_info_box_kwargs(**kwargs)
         super(MarkerOptions, self).__init__(**kwargs)
 
     def to_marker(self, latitude, longitude):
@@ -140,6 +146,7 @@ class Marker(GMapsWidgetMixin, _BaseMarkerMixin, widgets.Widget):
     label = Unicode("").tag(sync=True)
 
     def __init__(self, location, **kwargs):
+        kwargs = _resolve_info_box_kwargs(**kwargs)
         kwargs['location'] = location
         super(Marker, self).__init__(**kwargs)
 

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -229,3 +229,22 @@ class MarkerTest(unittest.TestCase):
     def test_location_non_kwarg(self):
         marker = Marker((10.0, 5.0))
         assert marker.get_state()['location'] == (10.0, 5.0)
+
+    def test_with_info_box(self):
+        marker = Marker((10.0, 5.0), info_box_content='test-content')
+        assert marker.display_info_box
+        assert marker.info_box_content == 'test-content'
+
+    def test_no_info_box(self):
+        marker = Marker(location=(10.0, 5.0))
+        assert not marker.display_info_box
+
+    def test_explicit_hide_info_box(self):
+        marker = Marker(
+            (10.0, 5.0),
+            display_info_box=False,
+            info_box_content='test-content'
+        )
+        assert not marker.display_info_box
+        assert marker.info_box_content == 'test-content'
+

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -247,4 +247,3 @@ class MarkerTest(unittest.TestCase):
         )
         assert not marker.display_info_box
         assert marker.info_box_content == 'test-content'
-

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -58,12 +58,12 @@ class BaseMarkerView extends widgets.WidgetView {
         const markerOptions = {
             position: {lat, lng},
             draggable: false,
-            clickable: false,
             title,
             ...styleOptions
         }
         this.marker = new google.maps.Marker(markerOptions)
         this.infoBox = this.renderInfoBox()
+        this.restoreClickable();
         this.infoBoxListener = null;
         this.mapView = null;
         this.modelEvents()
@@ -75,7 +75,8 @@ class BaseMarkerView extends widgets.WidgetView {
     }
 
     restoreClickable() {
-        this.marker.setClickable(false);
+        const clickable = this.displayInfoBox();
+        this.marker.setClickable(clickable);
     }
 
     displayInfoBox() {
@@ -90,6 +91,7 @@ class BaseMarkerView extends widgets.WidgetView {
     }
 
     toggleInfoBoxListener() {
+        this.restoreClickable();
         if (this.displayInfoBox()) {
             this.infoBoxListener = this.marker.addListener(
                 "click",


### PR DESCRIPTION
As part of building up the marker layer, we had disabled clicking on markers. This meant info boxes didn't work any more. Now fixed.