### PR TITLE
Split locations and weights into separate traitlets for weighted heatmaps

### DIFF
--- a/gmaps/geotraitlets.py
+++ b/gmaps/geotraitlets.py
@@ -8,6 +8,10 @@ class InvalidPointException(Exception):
     pass
 
 
+class InvalidWeightException(Exception):
+    pass
+
+
 class Latitude(traitlets.Float):
     """
     Float representing a latitude

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -112,6 +112,7 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     _model_name = Unicode('SimpleHeatmapLayerModel').tag(sync=True)
 
     data = List().tag(sync=True)
+    locations = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
 
     @validate('data')
@@ -122,7 +123,7 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
                     '{} is not a valid latitude, longitude pair'.format(point))
         return proposal['value']
 
-    @observe('data')
+    @observe('locations')
     def _calc_bounds(self, change):
         data = change['new']
         self.set_bounds(data)
@@ -163,6 +164,7 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     _model_name = Unicode('WeightedHeatmapLayerModel').tag(sync=True)
 
     data = List().tag(sync=True)
+    locations = List().tag(sync=True)
     weights = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
 
@@ -175,7 +177,7 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
             # check weight
         return proposal['value']
 
-    @observe('data')
+    @observe('locations')
     def _calc_bounds(self, change):
         data = change['new']
         self.set_bounds(data)
@@ -194,13 +196,13 @@ def _heatmap_options(
     locations_as_list = locations_to_list(locations)
     if weights is None:
         is_weighted = False
-        widget_args = {"data": locations_as_list}
+        widget_args = {'locations': locations_as_list}
     else:
         if len(weights) != len(locations):
             raise ValueError(
                 'weights must be of the same length as locations or None')
         is_weighted = True
-        widget_args = {'data': locations_as_list, 'weights': list(weights)}
+        widget_args = {'locations': locations_as_list, 'weights': list(weights)}
     widget_args.update(options)
     return widget_args, is_weighted
 

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -163,6 +163,7 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
         self.set_bounds(data)
 
 
+@doc_subst(_doc_snippets)
 class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     """
     Heatmap with weighted points.
@@ -175,6 +176,25 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     :func:`gmaps.heatmap_layer` factory function, passing in a
     parameter for `weights`.
 
+    {locations}
+
+    :param weights:
+        List of non-negative floats corresponding to the importance of
+        each latitude-longitude pair. Must have the same length as
+        `locations`.
+    :type weights: list of floats
+
+    {options}
+
+    :param data: DEPRECATED. Use `locations` and `weights` instead.
+        List of (latitude, longitude, weight) triples for a single
+        point. Latitudes are expressed as a float between -90 (corresponding to
+        90 degrees south) and +90 (corresponding to 90 degrees north).
+        Longitudes are expressed as a float between -180
+        (corresponding to 180 degrees west) and +180 (corresponding to
+        180 degrees east). Weights must be non-negative.
+    :type data: list of tuples
+
     :Examples:
 
     >>> fig = gmaps.figure()
@@ -183,15 +203,6 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     >>> heatmap = gmaps.heatmap_layer(locations, weights=weights)
     >>> heatmap.max_intensity = 2
     >>> fig.add_layer(heatmap_layer)
-
-    :param data: List of (latitude, longitude, weight) triples for a single
-        point. Latitudes are expressed as a float between -90 (corresponding to
-        90 degrees south) and +90 (corresponding to 90 degrees north).
-        Longitudes are expressed as a float between -180
-        (corresponding to 180 degrees west) and +180 (corresponding to
-        180 degrees east). Weights must be non-negative.
-    :type data: list of tuples
-
     """
     has_bounds = True
     _view_name = Unicode('WeightedHeatmapLayerView').tag(sync=True)

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -10,9 +10,21 @@ from . import bounds
 from .locations import locations_to_list, locations_docstring
 from . import geotraitlets
 from .maps import GMapsWidgetMixin
+from ._docutils import doc_subst
 
 
-_heatmap_options_docstring = """
+_doc_snippets = {}
+_doc_snippets['locations'] = """
+    :param locations: List of (latitude, longitude) pairs denoting a single
+        point. Latitudes are expressed as a float between -90
+        (corresponding to 90 degrees south) and +90 (corresponding to
+        90 degrees north). Longitudes are expressed as a float
+        between -180 (corresponding to 180 degrees west) and 180
+        (corresponding to 180 degrees east).
+    :type locations: list of tuples
+"""
+
+_doc_snippets['options'] = """
     :param max_intensity:
         Strictly positive floating point number indicating the numeric value
         that corresponds to the hottest colour in the heatmap gradient. Any
@@ -87,8 +99,9 @@ class _HeatmapOptionsMixin(HasTraits):
         return bounds.longitude_bounds(longitudes)
 
 
+@doc_subst(_doc_snippets)
 class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
-    __doc__ = """
+    """
     Heatmap layer.
 
     Add this to a ``Map`` instance to draw a heatmap. A heatmap shows
@@ -96,6 +109,19 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
 
     You should not instantiate this directly. Instead, use the
     :func:`gmaps.heatmap_layer` factory function.
+
+    {locations}
+
+    {options}
+
+    :param data: DEPRECATED. Use `locations` instead.
+        List of (latitude, longitude) pairs denoting a single
+        point. Latitudes are expressed as a float between -90
+        (corresponding to 90 degrees south) and +90 (corresponding to
+        90 degrees north). Longitudes are expressed as a float
+        between -180 (corresponding to 180 degrees west) and 180
+        (corresponding to 180 degrees east).
+    :type data: list of tuples
 
     :Examples:
 
@@ -107,15 +133,8 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     >>> heatmap.gradient = ['white', 'gray']
     >>> fig.add_layer(heatmap_layer)
 
-    :param data: List of (latitude, longitude) pairs denoting a single
-        point. Latitudes are expressed as a float between -90
-        (corresponding to 90 degrees south) and +90 (corresponding to
-        90 degrees north). Longitudes are expressed as a float
-        between -180 (corresponding to 180 degrees west) and 180
-        (corresponding to 180 degrees east).
-    :type data: list of tuples
 
-    """ + _heatmap_options_docstring
+    """
     has_bounds = True
     _view_name = Unicode('SimpleHeatmapLayerView').tag(sync=True)
     _model_name = Unicode('SimpleHeatmapLayerModel').tag(sync=True)
@@ -145,7 +164,7 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
 
 
 class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
-    __doc__ = """
+    """
     Heatmap with weighted points.
 
     Add this layer to a ``Map`` instance to draw a heatmap. Unlike the plain
@@ -173,7 +192,7 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
         180 degrees east). Weights must be non-negative.
     :type data: list of tuples
 
-    """ + _heatmap_options_docstring
+    """
     has_bounds = True
     _view_name = Unicode('WeightedHeatmapLayerView').tag(sync=True)
     _model_name = Unicode('WeightedHeatmapLayerModel').tag(sync=True)
@@ -233,21 +252,11 @@ def _heatmap_options(
     return widget_args, is_weighted
 
 
+@doc_subst(_doc_snippets)
 def heatmap_layer(
         locations, weights=None, max_intensity=None,
         dissipating=True, point_radius=None,
         opacity=0.6, gradient=None):
-    widget_args, is_weighted = _heatmap_options(
-        locations, weights, max_intensity, dissipating, point_radius,
-        opacity, gradient
-    )
-    if is_weighted:
-        return WeightedHeatmap(**widget_args)
-    else:
-        return Heatmap(**widget_args)
-
-
-heatmap_layer.__doc__ = \
     """
     Create a heatmap layer.
 
@@ -287,7 +296,14 @@ heatmap_layer.__doc__ = \
 
     :returns:
         A :class:`gmaps.Heatmap` or a :class:`gmaps.WeightedHeatmap` widget.
-    """.format(
-        locations=locations_docstring,
-        options=_heatmap_options_docstring
+    """
+    widget_args, is_weighted = _heatmap_options(
+        locations, weights, max_intensity, dissipating, point_radius,
+        opacity, gradient
     )
+    if is_weighted:
+        return WeightedHeatmap(**widget_args)
+    else:
+        return Heatmap(**widget_args)
+
+

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -237,7 +237,6 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
             weights.append(weight)
         return weights
 
-
     @observe('locations')
     def _calc_bounds(self, change):
         data = change['new']

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -111,7 +111,7 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     _view_name = Unicode('SimpleHeatmapLayerView').tag(sync=True)
     _model_name = Unicode('SimpleHeatmapLayerModel').tag(sync=True)
 
-    data = List().tag(sync=True)
+    data = List()
     locations = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
 
@@ -163,7 +163,7 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     _view_name = Unicode('WeightedHeatmapLayerView').tag(sync=True)
     _model_name = Unicode('WeightedHeatmapLayerModel').tag(sync=True)
 
-    data = List().tag(sync=True)
+    data = List()
     locations = List().tag(sync=True)
     weights = List().tag(sync=True)
     data_bounds = List().tag(sync=True)

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -57,7 +57,7 @@ class _HeatmapOptionsMixin(HasTraits):
         trait=geotraitlets.ColorAlpha(), allow_none=True, minlen=1
     ).tag(sync=True)
 
-    @default("gradient")
+    @default('gradient')
     def _default_gradient(self):
         return None
 
@@ -108,23 +108,23 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
 
     """ + _heatmap_options_docstring
     has_bounds = True
-    _view_name = Unicode("SimpleHeatmapLayerView").tag(sync=True)
-    _model_name = Unicode("SimpleHeatmapLayerModel").tag(sync=True)
+    _view_name = Unicode('SimpleHeatmapLayerView').tag(sync=True)
+    _model_name = Unicode('SimpleHeatmapLayerModel').tag(sync=True)
 
     data = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
 
-    @validate("data")
+    @validate('data')
     def _validate_data(self, proposal):
-        for point in proposal["value"]:
+        for point in proposal['value']:
             if not geotraitlets.is_valid_point(point):
                 raise geotraitlets.InvalidPointException(
-                    "{} is not a valid latitude, longitude pair".format(point))
-        return proposal["value"]
+                    '{} is not a valid latitude, longitude pair'.format(point))
+        return proposal['value']
 
-    @observe("data")
+    @observe('data')
     def _calc_bounds(self, change):
-        data = change["new"]
+        data = change['new']
         self.set_bounds(data)
 
 
@@ -159,25 +159,25 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
 
     """ + _heatmap_options_docstring
     has_bounds = True
-    _view_name = Unicode("WeightedHeatmapLayerView").tag(sync=True)
-    _model_name = Unicode("WeightedHeatmapLayerModel").tag(sync=True)
+    _view_name = Unicode('WeightedHeatmapLayerView').tag(sync=True)
+    _model_name = Unicode('WeightedHeatmapLayerModel').tag(sync=True)
 
     data = List().tag(sync=True)
     weights = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
 
-    @validate("data")
+    @validate('data')
     def _validate_data(self, proposal):
-        for point in proposal["value"]:
+        for point in proposal['value']:
             if not geotraitlets.is_valid_point(point[:2]):
                 raise geotraitlets.InvalidPointException(
-                    "{} is not a valid latitude, longitude pair".format(point))
+                    '{} is not a valid latitude, longitude pair'.format(point))
             # check weight
-        return proposal["value"]
+        return proposal['value']
 
-    @observe("data")
+    @observe('data')
     def _calc_bounds(self, change):
-        data = change["new"]
+        data = change['new']
         self.set_bounds(data)
 
 
@@ -185,11 +185,11 @@ def _heatmap_options(
         locations, weights, max_intensity, dissipating, point_radius,
         opacity, gradient):
     options = {
-        "max_intensity": max_intensity,
-        "dissipating": dissipating,
-        "point_radius": point_radius,
-        "opacity": opacity,
-        "gradient": gradient
+        'max_intensity': max_intensity,
+        'dissipating': dissipating,
+        'point_radius': point_radius,
+        'opacity': opacity,
+        'gradient': gradient
     }
     locations_as_list = locations_to_list(locations)
     if weights is None:
@@ -198,9 +198,9 @@ def _heatmap_options(
     else:
         if len(weights) != len(locations):
             raise ValueError(
-                "weights must be of the same length as locations or None")
+                'weights must be of the same length as locations or None')
         is_weighted = True
-        widget_args = {"data": locations_as_list, "weights": list(weights)}
+        widget_args = {'data': locations_as_list, 'weights': list(weights)}
     widget_args.update(options)
     return widget_args, is_weighted
 

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -115,7 +115,7 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     locations = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
 
-    @validate('data')
+    @validate('locations')
     def _validate_data(self, proposal):
         for point in proposal['value']:
             if not geotraitlets.is_valid_point(point):
@@ -168,12 +168,13 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     weights = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
 
-    @validate('data')
+    @validate('locations')
     def _validate_data(self, proposal):
         for point in proposal['value']:
-            if not geotraitlets.is_valid_point(point[:2]):
+            if not geotraitlets.is_valid_point(point):
                 raise geotraitlets.InvalidPointException(
-                    '{} is not a valid latitude, longitude pair'.format(point))
+                    '{} is not a valid latitude, longitude pair'.format(
+                        point))
             # check weight
         return proposal['value']
 

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -200,7 +200,7 @@ def _heatmap_options(
             raise ValueError(
                 "weights must be of the same length as locations or None")
         is_weighted = True
-        widget_args = {"data": locations_as_list, "weights": weights}
+        widget_args = {"data": locations_as_list, "weights": list(weights)}
     widget_args.update(options)
     return widget_args, is_weighted
 

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -163,6 +163,7 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     _model_name = Unicode("WeightedHeatmapLayerModel").tag(sync=True)
 
     data = List().tag(sync=True)
+    weights = List().tag(sync=True)
     data_bounds = List().tag(sync=True)
 
     @validate("data")
@@ -193,18 +194,13 @@ def _heatmap_options(
     locations_as_list = locations_to_list(locations)
     if weights is None:
         is_weighted = False
-        data = locations_as_list
+        widget_args = {"data": locations_as_list}
     else:
         if len(weights) != len(locations):
             raise ValueError(
                 "weights must be of the same length as locations or None")
         is_weighted = True
-        data = [
-            (latitude, longitude, weight) for
-            ((latitude, longitude), weight) in
-            zip(locations_as_list, weights)
-        ]
-    widget_args = {"data": data}
+        widget_args = {"data": locations_as_list, "weights": weights}
     widget_args.update(options)
     return widget_args, is_weighted
 

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -14,15 +14,7 @@ from ._docutils import doc_subst
 
 
 _doc_snippets = {}
-_doc_snippets['locations'] = """
-    :param locations: List of (latitude, longitude) pairs denoting a single
-        point. Latitudes are expressed as a float between -90
-        (corresponding to 90 degrees south) and +90 (corresponding to
-        90 degrees north). Longitudes are expressed as a float
-        between -180 (corresponding to 180 degrees west) and 180
-        (corresponding to 180 degrees east).
-    :type locations: list of tuples
-"""
+_doc_snippets['locations'] = locations_docstring
 
 _doc_snippets['options'] = """
     :param max_intensity:
@@ -314,5 +306,3 @@ def heatmap_layer(
         return WeightedHeatmap(**widget_args)
     else:
         return Heatmap(**widget_args)
-
-

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -132,8 +132,6 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     >>> heatmap.point_radius = 3
     >>> heatmap.gradient = ['white', 'gray']
     >>> fig.add_layer(heatmap_layer)
-
-
     """
     has_bounds = True
     _view_name = Unicode('SimpleHeatmapLayerView').tag(sync=True)

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -217,8 +217,26 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
                 raise geotraitlets.InvalidPointException(
                     '{} is not a valid latitude, longitude pair'.format(
                         point))
-            # check weight
         return proposal['value']
+
+    @validate('weights')
+    def _validate_weights(self, proposal):
+        weights = []
+        for weight in proposal['value']:
+            try:
+                weight = float(weight)
+            except (TypeError, ValueError):
+                raise geotraitlets.InvalidWeightException(
+                    '{} is not a valid weight. Weights must be floats.'.format(
+                        weight))
+            if weight < 0.0:
+                raise geotraitlets.InvalidWeightException(
+                    '{} is not a valid weight. Weights must be '
+                    'non-negative.'.format(weight)
+                )
+            weights.append(weight)
+        return weights
+
 
     @observe('locations')
     def _calc_bounds(self, change):

--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -225,7 +225,10 @@ def _heatmap_options(
             raise ValueError(
                 'weights must be of the same length as locations or None')
         is_weighted = True
-        widget_args = {'locations': locations_as_list, 'weights': list(weights)}
+        widget_args = {
+            'locations': locations_as_list,
+            'weights': list(weights)
+        }
     widget_args.update(options)
     return widget_args, is_weighted
 

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -66,14 +66,17 @@ class HeatmapLayer(unittest.TestCase):
         assert state['weights'] == self.weights
         assert state['data'] == self.locations
 
-#     def test_not_weighted_pandas_df(self):
-#         pd = pytest.importorskip("pandas")
-#         df = pd.DataFrame.from_records(
-#             self.locations, columns=["latitude", "longitude"])
-#         options = self._options_from_default()
-#         heatmap_args, is_weighted = _heatmap_options(df, **options)
-#         assert not is_weighted
-#         assert heatmap_args["data"] == self.locations
+    def test_not_weighted_pandas_df(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame.from_items([
+            ('latitude', [loc[0] for loc in self.locations]),
+            ('longitude', [loc[1] for loc in self.locations]),
+        ])
+        heatmap = heatmap_layer(df[['latitude', 'longitude']])
+        state = heatmap.get_state()
+        assert state['_view_name'] == 'SimpleHeatmapLayerView'
+        assert state['_model_name'] == 'SimpleHeatmapLayerModel'
+        assert state['data'] == self.locations
 
 #     def test_max_intensity(self):
 #         options = self._options_from_default(max_intensity=0.2)

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -132,6 +132,11 @@ class TestHeatmap(unittest.TestCase):
         heatmap = Heatmap(data=self.locations)
         assert heatmap.locations == self.locations
 
+    def test_change_data(self):
+        heatmap = Heatmap(locations=self.locations)
+        heatmap.data = self.locations * 2
+        assert heatmap.locations == self.locations * 2
+
 
 class TestWeightedHeatmap(unittest.TestCase):
 
@@ -147,3 +152,10 @@ class TestWeightedHeatmap(unittest.TestCase):
         heatmap = WeightedHeatmap(data=self.merged_location_weights)
         assert heatmap.locations == self.locations
         assert heatmap.weights == self.weights
+
+    def test_change_data(self):
+        heatmap = WeightedHeatmap(
+            locations=self.locations, weights=self.weights)
+        heatmap.data = self.merged_location_weights * 2
+        assert heatmap.locations == self.locations * 2
+        assert heatmap.weights == self.weights * 2

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -11,18 +11,6 @@ class HeatmapLayer(unittest.TestCase):
         self.locations = [(-5.0, 5.0), (10.0, 10.0)]
         self.weights = [0.2, 0.5]
 
-    def _options_from_default(self, **options_override):
-        default_options = {
-            'weights': None,
-            'max_intensity': None,
-            'dissipating': True,
-            'point_radius': None,
-            'opacity': 0.6,
-            'gradient': None
-        }
-        default_options.update(options_override)
-        return default_options
-
     def test_weighted(self):
         heatmap = heatmap_layer(self.locations, weights=self.weights)
         state = heatmap.get_state()

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -83,6 +83,26 @@ class HeatmapLayer(unittest.TestCase):
         state = heatmap.get_state()
         assert state['max_intensity'] == 0.2
 
+    def test_point_radius(self):
+        heatmap = heatmap_layer(self.locations, point_radius=2)
+        state = heatmap.get_state()
+        assert state['point_radius'] == 2
+
+    def test_dissipating(self):
+        heatmap = heatmap_layer(self.locations, dissipating=True)
+        state = heatmap.get_state()
+        assert state['dissipating']
+
+    def test_opacity(self):
+        heatmap = heatmap_layer(self.locations, opacity=0.4)
+        state = heatmap.get_state()
+        assert state['opacity'] == 0.4
+
+    def test_gradient(self):
+        heatmap = heatmap_layer(self.locations, gradient=['blue', 'red'])
+        state = heatmap.get_state()
+        assert state['gradient'] == ['blue', 'red']
+
 
 class TestHeatmapOptionsMixin(unittest.TestCase):
 

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -2,7 +2,8 @@
 import unittest
 import pytest
 
-from ..heatmap import _HeatmapOptionsMixin, heatmap_layer
+from ..heatmap import (
+    _HeatmapOptionsMixin, heatmap_layer, Heatmap, WeightedHeatmap)
 from ..geotraitlets import InvalidPointException
 
 
@@ -120,3 +121,29 @@ class TestHeatmapOptionsMixin(unittest.TestCase):
         layer = _HeatmapOptionsMixin(gradient=['blue', 'red'])
         layer.gradient = None
         assert layer.gradient is None
+
+
+class TestHeatmap(unittest.TestCase):
+
+    def setUp(self):
+        self.locations = [(-5.0, 5.0), (10.0, 10.0)]
+
+    def test_set_data(self):
+        heatmap = Heatmap(data=self.locations)
+        assert heatmap.locations == self.locations
+
+
+class TestWeightedHeatmap(unittest.TestCase):
+
+    def setUp(self):
+        self.locations = [(-5.0, 5.0), (10.0, 10.0)]
+        self.weights = [0.2, 0.5]
+        self.merged_location_weights = [
+            (-5.0, 5.0, 0.2),
+            (10.0, 10.0, 0.5),
+        ]
+
+    def test_set_data(self):
+        heatmap = WeightedHeatmap(data=self.merged_location_weights)
+        assert heatmap.locations == self.locations
+        assert heatmap.weights == self.weights

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -13,12 +13,12 @@ class HeatmapLayer(unittest.TestCase):
 
     def _options_from_default(self, **options_override):
         default_options = {
-            "weights": None,
-            "max_intensity": None,
-            "dissipating": True,
-            "point_radius": None,
-            "opacity": 0.6,
-            "gradient": None
+            'weights': None,
+            'max_intensity': None,
+            'dissipating': True,
+            'point_radius': None,
+            'opacity': 0.6,
+            'gradient': None
         }
         default_options.update(options_override)
         return default_options
@@ -67,7 +67,7 @@ class HeatmapLayer(unittest.TestCase):
         assert state['data'] == self.locations
 
     def test_not_weighted_pandas_df(self):
-        pd = pytest.importorskip("pandas")
+        pd = pytest.importorskip('pandas')
         df = pd.DataFrame.from_items([
             ('latitude', [loc[0] for loc in self.locations]),
             ('longitude', [loc[1] for loc in self.locations]),
@@ -111,10 +111,10 @@ class TestHeatmapOptionsMixin(unittest.TestCase):
         assert layer.gradient is None
 
     def test_gradient_default_values(self):
-        layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
-        assert layer.gradient == ["blue", "red"]
+        layer = _HeatmapOptionsMixin(gradient=['blue', 'red'])
+        assert layer.gradient == ['blue', 'red']
 
     def test_gradient_set_none(self):
-        layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
+        layer = _HeatmapOptionsMixin(gradient=['blue', 'red'])
         layer.gradient = None
         assert layer.gradient is None

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -78,11 +78,10 @@ class HeatmapLayer(unittest.TestCase):
         assert state['_model_name'] == 'SimpleHeatmapLayerModel'
         assert state['data'] == self.locations
 
-#     def test_max_intensity(self):
-#         options = self._options_from_default(max_intensity=0.2)
-#         heatmap_args, is_weigthed = _heatmap_options(
-#             self.locations, **options)
-#         assert heatmap_args["max_intensity"] == 0.2
+    def test_max_intensity(self):
+        heatmap = heatmap_layer(self.locations, max_intensity=0.2)
+        state = heatmap.get_state()
+        assert state['max_intensity'] == 0.2
 
 
 class TestHeatmapOptionsMixin(unittest.TestCase):

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -40,13 +40,14 @@ class HeatmapLayer(unittest.TestCase):
         assert state['weights'] == self.weights
         assert state['data'] == self.locations
 
-#     def test_not_weighted_numpy_array(self):
-#         import numpy as np
-#         locations = np.array(self.locations)
-#         options = self._options_from_default()
-#         heatmap_args, is_weighted = _heatmap_options(locations, **options)
-#         assert not is_weighted
-#         assert heatmap_args["data"] == self.locations
+    def test_not_weighted_numpy_array(self):
+        import numpy as np
+        locations = np.array(self.locations)
+        heatmap = heatmap_layer(locations)
+        state = heatmap.get_state()
+        assert state['_view_name'] == 'SimpleHeatmapLayerView'
+        assert state['_model_name'] == 'SimpleHeatmapLayerModel'
+        assert state['data'] == self.locations
 
 #     def test_weighted_pandas_df(self):
 #         pd = pytest.importorskip("pandas")

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -3,6 +3,7 @@ import unittest
 import pytest
 
 from ..heatmap import _HeatmapOptionsMixin, heatmap_layer
+from ..geotraitlets import InvalidPointException
 
 
 class HeatmapLayer(unittest.TestCase):
@@ -99,6 +100,10 @@ class HeatmapLayer(unittest.TestCase):
         heatmap = heatmap_layer(self.locations, gradient=['blue', 'red'])
         state = heatmap.get_state()
         assert state['gradient'] == ['blue', 'red']
+
+    def test_invalid_location(self):
+        with self.assertRaises(InvalidPointException):
+            heatmap_layer([(1.0, -200.0)])
 
 
 class TestHeatmapOptionsMixin(unittest.TestCase):

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -17,7 +17,7 @@ class HeatmapLayer(unittest.TestCase):
         assert state['_view_name'] == 'WeightedHeatmapLayerView'
         assert state['_model_name'] == 'WeightedHeatmapLayerModel'
         assert state['weights'] == self.weights
-        assert state['data'] == self.locations
+        assert state['locations'] == self.locations
 
     def test_weighted_numpy_array(self):
         import numpy as np
@@ -26,7 +26,7 @@ class HeatmapLayer(unittest.TestCase):
         heatmap = heatmap_layer(locations, weights=weights)
         state = heatmap.get_state()
         assert state['weights'] == self.weights
-        assert state['data'] == self.locations
+        assert state['locations'] == self.locations
 
     def test_not_weighted_numpy_array(self):
         import numpy as np
@@ -35,7 +35,7 @@ class HeatmapLayer(unittest.TestCase):
         state = heatmap.get_state()
         assert state['_view_name'] == 'SimpleHeatmapLayerView'
         assert state['_model_name'] == 'SimpleHeatmapLayerModel'
-        assert state['data'] == self.locations
+        assert state['locations'] == self.locations
 
     def test_weighted_pandas_df(self):
         pd = pytest.importorskip('pandas')
@@ -52,7 +52,7 @@ class HeatmapLayer(unittest.TestCase):
         assert state['_view_name'] == 'WeightedHeatmapLayerView'
         assert state['_model_name'] == 'WeightedHeatmapLayerModel'
         assert state['weights'] == self.weights
-        assert state['data'] == self.locations
+        assert state['locations'] == self.locations
 
     def test_not_weighted_pandas_df(self):
         pd = pytest.importorskip('pandas')
@@ -64,7 +64,7 @@ class HeatmapLayer(unittest.TestCase):
         state = heatmap.get_state()
         assert state['_view_name'] == 'SimpleHeatmapLayerView'
         assert state['_model_name'] == 'SimpleHeatmapLayerModel'
-        assert state['data'] == self.locations
+        assert state['locations'] == self.locations
 
     def test_defaults(self):
         heatmap = heatmap_layer(self.locations)

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -85,17 +85,17 @@ class HeatmapLayer(unittest.TestCase):
 #         assert heatmap_args["max_intensity"] == 0.2
 
 
-# class TestHeatmapOptionsMixin(unittest.TestCase):
+class TestHeatmapOptionsMixin(unittest.TestCase):
 
-#     def test_gradient_default_none(self):
-#         layer = _HeatmapOptionsMixin()
-#         assert layer.gradient is None
+    def test_gradient_default_none(self):
+        layer = _HeatmapOptionsMixin()
+        assert layer.gradient is None
 
-#     def test_gradient_default_values(self):
-#         layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
-#         assert layer.gradient == ["blue", "red"]
+    def test_gradient_default_values(self):
+        layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
+        assert layer.gradient == ["blue", "red"]
 
-#     def test_gradient_set_none(self):
-#         layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
-#         layer.gradient = None
-#         assert layer.gradient is None
+    def test_gradient_set_none(self):
+        layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
+        layer.gradient = None
+        assert layer.gradient is None

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -66,6 +66,15 @@ class HeatmapLayer(unittest.TestCase):
         assert state['_model_name'] == 'SimpleHeatmapLayerModel'
         assert state['data'] == self.locations
 
+    def test_defaults(self):
+        heatmap = heatmap_layer(self.locations)
+        state = heatmap.get_state()
+        assert state['max_intensity'] is None
+        assert state['opacity'] == 0.6
+        assert state['point_radius'] is None
+        assert state['dissipating']
+        assert state['gradient'] is None
+
     def test_max_intensity(self):
         heatmap = heatmap_layer(self.locations, max_intensity=0.2)
         state = heatmap.get_state()
@@ -77,9 +86,9 @@ class HeatmapLayer(unittest.TestCase):
         assert state['point_radius'] == 2
 
     def test_dissipating(self):
-        heatmap = heatmap_layer(self.locations, dissipating=True)
+        heatmap = heatmap_layer(self.locations, dissipating=False)
         state = heatmap.get_state()
-        assert state['dissipating']
+        assert not state['dissipating']
 
     def test_opacity(self):
         heatmap = heatmap_layer(self.locations, opacity=0.4)

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -2,7 +2,7 @@
 import unittest
 import pytest
 
-from ..heatmap import _heatmap_options, _HeatmapOptionsMixin, heatmap_layer
+from ..heatmap import _HeatmapOptionsMixin, heatmap_layer
 
 
 class HeatmapLayer(unittest.TestCase):

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..heatmap import (
     _HeatmapOptionsMixin, heatmap_layer, Heatmap, WeightedHeatmap)
-from ..geotraitlets import InvalidPointException
+from ..geotraitlets import InvalidPointException, InvalidWeightException
 
 
 class HeatmapLayer(unittest.TestCase):
@@ -159,3 +159,11 @@ class TestWeightedHeatmap(unittest.TestCase):
         heatmap.data = self.merged_location_weights * 2
         assert heatmap.locations == self.locations * 2
         assert heatmap.weights == self.weights * 2
+
+    def test_non_float_weights(self):
+        with self.assertRaises(InvalidWeightException):
+            WeightedHeatmap(locations=self.locations, weights=['not', 'float'])
+
+    def test_negative_weights(self):
+        with self.assertRaises(InvalidWeightException):
+            WeightedHeatmap(locations=self.locations, weights=[1.0, -2.0])

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -31,14 +31,14 @@ class HeatmapLayer(unittest.TestCase):
         assert state['weights'] == self.weights
         assert state['data'] == self.locations
 
-#     def test_weighted_numpy_array(self):
-#         import numpy as np
-#         locations = np.array(self.locations)
-#         weights = np.array(self.weights)
-#         options = self._options_from_default(weights=weights)
-#         heatmap_args, is_weighted = _heatmap_options(locations, **options)
-#         assert is_weighted
-#         assert heatmap_args["data"] == self.merged_weight_locations
+    def test_weighted_numpy_array(self):
+        import numpy as np
+        locations = np.array(self.locations)
+        weights = np.array(self.weights)
+        heatmap = heatmap_layer(locations, weights=weights)
+        state = heatmap.get_state()
+        assert state['weights'] == self.weights
+        assert state['data'] == self.locations
 
 #     def test_not_weighted_numpy_array(self):
 #         import numpy as np

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -49,18 +49,22 @@ class HeatmapLayer(unittest.TestCase):
         assert state['_model_name'] == 'SimpleHeatmapLayerModel'
         assert state['data'] == self.locations
 
-#     def test_weighted_pandas_df(self):
-#         pd = pytest.importorskip("pandas")
-#         df = pd.DataFrame.from_items([
-#             ("latitude", [loc[0] for loc in self.locations]),
-#             ("longitude", [loc[1] for loc in self.locations]),
-#             ("weight", self.weights)
-#         ])
-#         options = self._options_from_default(weights=df["weight"])
-#         heatmap_args, is_weighted = _heatmap_options(
-#             df[["latitude", "longitude"]], **options)
-#         assert is_weighted
-#         assert heatmap_args["data"] == self.merged_weight_locations
+    def test_weighted_pandas_df(self):
+        pd = pytest.importorskip('pandas')
+        df = pd.DataFrame.from_items([
+            ('latitude', [loc[0] for loc in self.locations]),
+            ('longitude', [loc[1] for loc in self.locations]),
+            ('weight', self.weights)
+        ])
+        heatmap = heatmap_layer(
+            df[['latitude', 'longitude']],
+            weights=df['weight']
+        )
+        state = heatmap.get_state()
+        assert state['_view_name'] == 'WeightedHeatmapLayerView'
+        assert state['_model_name'] == 'WeightedHeatmapLayerModel'
+        assert state['weights'] == self.weights
+        assert state['data'] == self.locations
 
 #     def test_not_weighted_pandas_df(self):
 #         pd = pytest.importorskip("pandas")

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -2,7 +2,7 @@
 import unittest
 import pytest
 
-from ..heatmap import _heatmap_options, _HeatmapOptionsMixin
+from ..heatmap import _heatmap_options, _HeatmapOptionsMixin, heatmap_layer
 
 
 class HeatmapLayer(unittest.TestCase):
@@ -10,10 +10,6 @@ class HeatmapLayer(unittest.TestCase):
     def setUp(self):
         self.locations = [(-5.0, 5.0), (10.0, 10.0)]
         self.weights = [0.2, 0.5]
-        self.merged_weight_locations = [
-            (-5.0, 5.0, 0.2),
-            (10.0, 10.0, 0.5)
-        ]
 
     def _options_from_default(self, **options_override):
         default_options = {
@@ -28,69 +24,70 @@ class HeatmapLayer(unittest.TestCase):
         return default_options
 
     def test_weighted(self):
-        options = self._options_from_default(weights=self.weights)
-        heatmap_args, is_weighted = _heatmap_options(
-            self.locations, **options)
-        assert is_weighted
-        assert heatmap_args["data"] == self.merged_weight_locations
+        heatmap = heatmap_layer(self.locations, weights=self.weights)
+        state = heatmap.get_state()
+        assert state['_view_name'] == 'WeightedHeatmapLayerView'
+        assert state['_model_name'] == 'WeightedHeatmapLayerModel'
+        assert state['weights'] == self.weights
+        assert state['data'] == self.locations
 
-    def test_weighted_numpy_array(self):
-        import numpy as np
-        locations = np.array(self.locations)
-        weights = np.array(self.weights)
-        options = self._options_from_default(weights=weights)
-        heatmap_args, is_weighted = _heatmap_options(locations, **options)
-        assert is_weighted
-        assert heatmap_args["data"] == self.merged_weight_locations
+#     def test_weighted_numpy_array(self):
+#         import numpy as np
+#         locations = np.array(self.locations)
+#         weights = np.array(self.weights)
+#         options = self._options_from_default(weights=weights)
+#         heatmap_args, is_weighted = _heatmap_options(locations, **options)
+#         assert is_weighted
+#         assert heatmap_args["data"] == self.merged_weight_locations
 
-    def test_not_weighted_numpy_array(self):
-        import numpy as np
-        locations = np.array(self.locations)
-        options = self._options_from_default()
-        heatmap_args, is_weighted = _heatmap_options(locations, **options)
-        assert not is_weighted
-        assert heatmap_args["data"] == self.locations
+#     def test_not_weighted_numpy_array(self):
+#         import numpy as np
+#         locations = np.array(self.locations)
+#         options = self._options_from_default()
+#         heatmap_args, is_weighted = _heatmap_options(locations, **options)
+#         assert not is_weighted
+#         assert heatmap_args["data"] == self.locations
 
-    def test_weighted_pandas_df(self):
-        pd = pytest.importorskip("pandas")
-        df = pd.DataFrame.from_items([
-            ("latitude", [loc[0] for loc in self.locations]),
-            ("longitude", [loc[1] for loc in self.locations]),
-            ("weight", self.weights)
-        ])
-        options = self._options_from_default(weights=df["weight"])
-        heatmap_args, is_weighted = _heatmap_options(
-            df[["latitude", "longitude"]], **options)
-        assert is_weighted
-        assert heatmap_args["data"] == self.merged_weight_locations
+#     def test_weighted_pandas_df(self):
+#         pd = pytest.importorskip("pandas")
+#         df = pd.DataFrame.from_items([
+#             ("latitude", [loc[0] for loc in self.locations]),
+#             ("longitude", [loc[1] for loc in self.locations]),
+#             ("weight", self.weights)
+#         ])
+#         options = self._options_from_default(weights=df["weight"])
+#         heatmap_args, is_weighted = _heatmap_options(
+#             df[["latitude", "longitude"]], **options)
+#         assert is_weighted
+#         assert heatmap_args["data"] == self.merged_weight_locations
 
-    def test_not_weighted_pandas_df(self):
-        pd = pytest.importorskip("pandas")
-        df = pd.DataFrame.from_records(
-            self.locations, columns=["latitude", "longitude"])
-        options = self._options_from_default()
-        heatmap_args, is_weighted = _heatmap_options(df, **options)
-        assert not is_weighted
-        assert heatmap_args["data"] == self.locations
+#     def test_not_weighted_pandas_df(self):
+#         pd = pytest.importorskip("pandas")
+#         df = pd.DataFrame.from_records(
+#             self.locations, columns=["latitude", "longitude"])
+#         options = self._options_from_default()
+#         heatmap_args, is_weighted = _heatmap_options(df, **options)
+#         assert not is_weighted
+#         assert heatmap_args["data"] == self.locations
 
-    def test_max_intensity(self):
-        options = self._options_from_default(max_intensity=0.2)
-        heatmap_args, is_weigthed = _heatmap_options(
-            self.locations, **options)
-        assert heatmap_args["max_intensity"] == 0.2
+#     def test_max_intensity(self):
+#         options = self._options_from_default(max_intensity=0.2)
+#         heatmap_args, is_weigthed = _heatmap_options(
+#             self.locations, **options)
+#         assert heatmap_args["max_intensity"] == 0.2
 
 
-class TestHeatmapOptionsMixin(unittest.TestCase):
+# class TestHeatmapOptionsMixin(unittest.TestCase):
 
-    def test_gradient_default_none(self):
-        layer = _HeatmapOptionsMixin()
-        assert layer.gradient is None
+#     def test_gradient_default_none(self):
+#         layer = _HeatmapOptionsMixin()
+#         assert layer.gradient is None
 
-    def test_gradient_default_values(self):
-        layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
-        assert layer.gradient == ["blue", "red"]
+#     def test_gradient_default_values(self):
+#         layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
+#         assert layer.gradient == ["blue", "red"]
 
-    def test_gradient_set_none(self):
-        layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
-        layer.gradient = None
-        assert layer.gradient is None
+#     def test_gradient_set_none(self):
+#         layer = _HeatmapOptionsMixin(gradient=["blue", "red"])
+#         layer.gradient = None
+#         assert layer.gradient is None

--- a/js/src/Heatmap.js
+++ b/js/src/Heatmap.js
@@ -73,7 +73,7 @@ class HeatmapLayerBaseView extends GMapsLayerView {
 
 export class SimpleHeatmapLayerView extends HeatmapLayerBaseView {
     getData() {
-        const data = this.model.get("data")
+        const data = this.model.get("locations")
         const dataAsGoogle = new google.maps.MVCArray(
             data.map(([lat, lng]) => new google.maps.LatLng(lat, lng))
         )
@@ -84,7 +84,7 @@ export class SimpleHeatmapLayerView extends HeatmapLayerBaseView {
 
 export class WeightedHeatmapLayerView extends HeatmapLayerBaseView {
     getData() {
-        const data = this.model.get("data")
+        const data = this.model.get("locations")
         const weights = this.model.get("weights")
         const dataAsGoogle = new google.maps.MVCArray(
             data.map(([lat, lng], i) => {

--- a/js/src/Heatmap.js
+++ b/js/src/Heatmap.js
@@ -85,10 +85,12 @@ export class SimpleHeatmapLayerView extends HeatmapLayerBaseView {
 export class WeightedHeatmapLayerView extends HeatmapLayerBaseView {
     getData() {
         const data = this.model.get("data")
+        const weights = this.model.get("weights")
         const dataAsGoogle = new google.maps.MVCArray(
-            data.map(([lat, lng, weight]) => {
+            data.map(([lat, lng], i) => {
+                const weight = weights[i];
                 const location = new google.maps.LatLng(lat, lng)
-                return { location: location, weight: weight }
+                return { location, weight }
             })
         );
         return dataAsGoogle


### PR DESCRIPTION
Prior to this PR, weighted heatmaps combined weight and location data into a single traitlet. This doesn't make much sense -- having two separate traitlets allows changing locations and weights independently, which will help resolve issue #188 .

Left to do:

 - [x] Restore backwards compatibility with a deprecation warning
 - [x] Validate weight traitlet (both that weights are positive ~~and that the length matches that of the location traitlet~~).
 - [x] Update docstring