### PR TITLE
Allow downloading drawing layer as PNG

### DIFF
--- a/js/src/Drawing.js
+++ b/js/src/Drawing.js
@@ -211,7 +211,7 @@ export class DrawingControlsModel extends widgets.DOMWidgetModel {
 export class DrawingLayerView extends GMapsLayerView {
     constructor(options) {
         super(options);
-        this.canDownloadAsPng = false;
+        this.canDownloadAsPng = true;
         this._clickHandler = null;
     }
 


### PR DESCRIPTION
This was explicitly disabled, mostly because it was untested. Now fixed.

Addresses issue #224 .

![map 24](https://user-images.githubusercontent.com/1392879/38126386-2ea3889a-33e8-11e8-922a-eb627374a1a7.png)
