### PR TITLE
Avoid unnecessary log

### DIFF
--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -64,7 +64,6 @@ If you see <code>InvalidKeyMapError</code>, the key you passed in is invalid. If
 const ConfigurationMixin = (superclass) => class extends superclass {
     loadConfiguration() {
         const modelConfiguration = this.model.get('configuration')
-        console.log(modelConfiguration)
         reloadGoogleMaps(modelConfiguration)
     }
 }


### PR DESCRIPTION
PR #240 introduced a log in `loadConfiguration`. We logged the configuration passed to `gmaps`, including the API key, which is probably a bad thing.