### PR TITLE
Add styling to errors box

### DIFF
--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -43,6 +43,7 @@ export class ErrorsBoxModel extends widgets.DOMWidgetModel {
 
 export class ErrorsBoxView extends widgets.DOMWidgetView {
     render() {
+        this.$el.addClass('gmaps-errors-box-container')
         this._renderErrors()
         this.model.on('change:errors', () => this._renderErrors())
     }
@@ -51,7 +52,7 @@ export class ErrorsBoxView extends widgets.DOMWidgetView {
         const errorContainer = $('<ul />').addClass('gmaps-error-box')
         this.model.get('errors').map(
             (message, ierror) =>
-                $(`<li><pre>${message}</pre></li>`)
+                $(`<li class="well well-sm"><pre>${message}</pre></li>`)
                     .click(() => this.model.removeError(ierror))
         ).forEach(element => errorContainer.append(element))
         this.$el.empty(); // Clear the current state

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -1,5 +1,6 @@
 import * as widgets from '@jupyter-widgets/base'
 import _ from 'underscore'
+import $ from 'jquery'
 
 import GoogleMapsLoader from 'google-maps'
 

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -23,6 +23,8 @@ export class ToolbarModel extends widgets.DOMWidgetModel {
 export class ToolbarView extends widgets.DOMWidgetView {
 
     render() {
+        this.$el.addClass('gmaps-toolbar-container')
+
         const $toolbar = $("<div />");
         $toolbar
             .addClass("gmaps-toolbar toolbar-inner navbar-inner");

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -1,11 +1,17 @@
 
+.gmaps-toolbar-container {
+    overflow: visible;
+}
+
 .gmaps-toolbar {
+
+  margin-top: 2px;
+  margin-bottom: 5px;
+
   .toolbar {
+    width: 100%;
     margin-left: 0px;
     margin-right: 0px;
-    margin-top: 2px;
-    margin-bottom: 5px;
-    width: 100%;
   }
 
   .btn {
@@ -43,18 +49,27 @@
 
 }
 
+.gmaps-errors-box-container {
+    overflow: visible;
+}
+
 .gmaps-error-box {
   padding-left: 0px;
+  margin-top: 2px;
   margin-bottom: 0px;
 
   pre {
     padding-top: 5px;
     padding-bottom: 5px;
-    margin-bottom: 5px;
   }
 
-  li {
+  .well {
     cursor: pointer;
+    margin-bottom: 10px;
+  }
+
+  .well.well-sm {
+      padding: 6px;
   }
 }
 


### PR DESCRIPTION
Because of changes in the notebook CSS, the styling around the errors box had disappeared. This PR re-enables it.

<img width="849" alt="screen shot 2018-04-18 at 06 50 44" src="https://user-images.githubusercontent.com/1392879/38913870-d9d4cbca-42d4-11e8-9df5-543fedd39491.png">
