### PR TITLE
Define Opacity traitlet

### DIFF
--- a/gmaps/directions.py
+++ b/gmaps/directions.py
@@ -180,8 +180,8 @@ class Directions(GMapsWidgetMixin, widgets.Widget):
     show_route = Bool(default_value=True).tag(sync=True)
     stroke_color = geotraitlets.ColorAlpha(
         default_value=DEFAULT_STROKE_COLOR, allow_none=False).tag(sync=True)
-    stroke_opacity = Float(
-        min=0.0, max=1.0, default_value=0.6, allow_none=False).tag(sync=True)
+    stroke_opacity = geotraitlets.Opacity(
+        default_value=0.6, allow_none=False).tag(sync=True)
     stroke_weight = Float(
         min=0.0, allow_none=False, default_value=6.0).tag(sync=True)
 

--- a/gmaps/drawing.py
+++ b/gmaps/drawing.py
@@ -200,9 +200,8 @@ class LineOptions(HasTraits):
     stroke_weight = Float(
         min=0.0, allow_none=False, default_value=2.0
     ).tag(sync=True)
-    stroke_opacity = Float(
-        min=0.0, max=1.0, allow_none=False, default_value=0.6
-    ).tag(sync=True)
+    stroke_opacity = geotraitlets.Opacity(
+        allow_none=False, default_value=0.6).tag(sync=True)
 
     def to_line(self, start, end):
         new_line = Line(
@@ -276,9 +275,8 @@ class Line(GMapsWidgetMixin, widgets.Widget):
     stroke_weight = Float(
         min=0.0, allow_none=False, default_value=2.0
     ).tag(sync=True)
-    stroke_opacity = Float(
-        min=0.0, max=1.0, allow_none=False, default_value=0.6
-    ).tag(sync=True)
+    stroke_opacity = geotraitlets.Opacity(
+        allow_none=False, default_value=0.6).tag(sync=True)
 
     def __init__(
             self, start, end,
@@ -322,15 +320,13 @@ class PolygonOptions(HasTraits):
     stroke_weight = Float(
         min=0.0, allow_none=False, default_value=2.0
     ).tag(sync=True)
-    stroke_opacity = Float(
-        min=0.0, max=1.0, allow_none=False, default_value=0.6
-    ).tag(sync=True)
+    stroke_opacity = geotraitlets.Opacity(
+        allow_none=False, default_value=0.6).tag(sync=True)
     fill_color = geotraitlets.ColorAlpha(
         allow_none=False, default_value=DEFAULT_FILL_COLOR
     ).tag(sync=True)
-    fill_opacity = Float(
-        min=0.0, max=1.0, allow_none=False, default_value=0.2
-    ).tag(sync=True)
+    fill_opacity = geotraitlets.Opacity(
+        allow_none=False, default_value=0.2).tag(sync=True)
 
     def to_polygon(self, path):
         new_polygon = Polygon(
@@ -400,15 +396,13 @@ class Polygon(GMapsWidgetMixin, widgets.Widget):
     stroke_weight = Float(
         min=0.0, allow_none=False, default_value=2.0
     ).tag(sync=True)
-    stroke_opacity = Float(
-        min=0.0, max=1.0, allow_none=False, default_value=0.6
-    ).tag(sync=True)
+    stroke_opacity = geotraitlets.Opacity(
+        allow_none=False, default_value=0.6).tag(sync=True)
     fill_color = geotraitlets.ColorAlpha(
         allow_none=False, default_value=DEFAULT_FILL_COLOR
     ).tag(sync=True)
-    fill_opacity = Float(
-        min=0.0, max=1.0, allow_none=False, default_value=0.2
-    ).tag(sync=True)
+    fill_opacity = geotraitlets.Opacity(
+        allow_none=False, default_value=0.2).tag(sync=True)
 
     def __init__(
             self, path,

--- a/gmaps/geojson_layer.py
+++ b/gmaps/geojson_layer.py
@@ -34,11 +34,10 @@ class GeoJsonFeature(GMapsWidgetMixin, widgets.Widget):
     fill_color = geotraitlets.ColorAlpha(
         allow_none=True, default_value=None
     ).tag(sync=True)
-    fill_opacity = Float(min=0.0, max=1.0, default_value=1.0).tag(sync=True)
+    fill_opacity = geotraitlets.Opacity(default_value=1.0).tag(sync=True)
     stroke_color = geotraitlets.ColorAlpha(
-        allow_none=True, default_value=None
-    ).tag(sync=True)
-    stroke_opacity = Float(min=0.0, max=1.0, default_value=1.0).tag(sync=True)
+        allow_none=True, default_value=None).tag(sync=True)
+    stroke_opacity = geotraitlets.Opacity(default_value=1.0).tag(sync=True)
     stroke_weight = Float(min=0.0, default_value=1.0).tag(sync=True)
 
     def get_coords(self):

--- a/gmaps/geotraitlets.py
+++ b/gmaps/geotraitlets.py
@@ -59,7 +59,7 @@ class Latitude(traitlets.Float):
 
     Latitude values must be between -90 and 90.
     """
-    info_text = "a valid latitude (-90 <= latitude <= 90)"
+    info_text = 'a valid latitude (-90 <= latitude <= 90)'
     default_value = traitlets.Undefined
 
     def validate(self, obj, value):
@@ -73,7 +73,7 @@ class Longitude(traitlets.Float):
 
     Longitude values must be between -180 and 180.
     """
-    info_text = "a valid longitude (-180 <= longitude <= 180)"
+    info_text = 'a valid longitude (-180 <= longitude <= 180)'
     default_value = traitlets.Undefined
 
     def validate(self, obj, value):
@@ -85,7 +85,7 @@ class Point(traitlets.Tuple):
     """
     Tuple representing a (latitude, longitude) pair.
     """
-    info_text = "a valid (latitude, longitude) pair"
+    info_text = 'a valid (latitude, longitude) pair'
 
     def __init__(self, default_value=traitlets.Undefined):
         super(Point, self).__init__(
@@ -103,9 +103,9 @@ class Point(traitlets.Tuple):
 
 
 _color_names = {
-    "black", "silver", "gray", "white", "maroon", "red",
-    "purple", "fuschia", "green", "lime", "olive",
-    "yellow", "navy", "blue", "teal", "aqua"
+    'black', 'silver', 'gray', 'white', 'maroon', 'red',
+    'purple', 'fuschia', 'green', 'lime', 'olive',
+    'yellow', 'navy', 'blue', 'teal', 'aqua'
 }
 
 _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
@@ -132,7 +132,7 @@ class ColorString(traitlets.Unicode):
     def validate(self, obj, value):
         try:
             value_as_string = super(ColorString, self).validate(obj, value)
-            normalised_string = value_as_string.replace(" ", "").lower()
+            normalised_string = value_as_string.replace(' ', '').lower()
             if (
                 normalised_string.lower() in _color_names or
                 _color_re.match(normalised_string) or
@@ -147,7 +147,7 @@ class ColorString(traitlets.Unicode):
 
 
 class RgbTuple(traitlets.Tuple):
-    info_text = "a triple of integers between 0 and 255 like (100, 0, 250)"
+    info_text = 'a triple of integers between 0 and 255 like (100, 0, 250)'
 
     def __init__(self, **metadata):
         traits = [
@@ -159,7 +159,7 @@ class RgbTuple(traitlets.Tuple):
 
 
 class RgbaTuple(traitlets.Tuple):
-    info_text = "an RGBA tuple like (100, 0, 250, 0.5)"
+    info_text = 'an RGBA tuple like (100, 0, 250, 0.5)'
 
     def __init__(self, **metadata):
         traits = [
@@ -175,7 +175,7 @@ class ZoomLevel(traitlets.Integer):
     """
     Integer representing a zoom value allowed by Google Maps
     """
-    info_text = "a valid Google Maps zoom (0 <= zoom <= 21)"
+    info_text = 'a valid Google Maps zoom (0 <= zoom <= 21)'
     default_value = traitlets.Undefined
 
     def validate(self, obj, value):
@@ -211,10 +211,10 @@ class ColorAlpha(traitlets.Union):
         if isinstance(value, tuple):
             if len(value) == 3:
                 # convert to an rgb string
-                return "rgb({},{},{})".format(*value)
+                return 'rgb({},{},{})'.format(*value)
             else:
                 # convert to an rgba string
-                return "rgba({},{},{},{})".format(*value)
+                return 'rgba({},{},{},{})'.format(*value)
         else:
             # already a string
             return value
@@ -251,7 +251,7 @@ class MouseHandling(traitlets.Enum):
 
 
 class Opacity(traitlets.Float):
-    info_text = "a valid opacity value (0.0 <= opacity <= 1.0)"
+    info_text = 'a valid opacity value (0.0 <= opacity <= 1.0)'
 
     def __init__(
             self, default_value=traitlets.Undefined,

--- a/gmaps/geotraitlets.py
+++ b/gmaps/geotraitlets.py
@@ -250,6 +250,21 @@ class MouseHandling(traitlets.Enum):
         )
 
 
+class Opacity(traitlets.Float):
+    info_text = "a valid opacity value (0.0 <= opacity <= 1.0)"
+
+    def __init__(
+            self, default_value=traitlets.Undefined,
+            allow_none=False, **kwargs
+    ):
+        super(Opacity, self).__init__(
+            default_value=default_value,
+            allow_none=allow_none,
+            min=0.0,
+            max=1.0,
+            **kwargs)
+
+
 def is_valid_point(pt):
     latitude, longitude = pt
     return (-90.0 <= latitude <= 90.0) and (-180.0 <= longitude <= 180.0)

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -115,11 +115,11 @@ class Symbol(GMapsWidgetMixin, _BaseMarkerMixin, widgets.Widget):
     fill_color = geotraitlets.ColorAlpha(
         allow_none=True, default_value=None
     ).tag(sync=True)
-    fill_opacity = Float(min=0.0, max=1.0, default_value=1.0).tag(sync=True)
+    fill_opacity = geotraitlets.Opacity(default_value=1.0).tag(sync=True)
     stroke_color = geotraitlets.ColorAlpha(
         allow_none=True, default_value=None
     ).tag(sync=True)
-    stroke_opacity = Float(min=0.0, max=1.0, default_value=1.0).tag(sync=True)
+    stroke_opacity = geotraitlets.Opacity(default_value=1.0).tag(sync=True)
     scale = Int(
         default_value=4, allow_none=True, min=1
     ).tag(sync=True)

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -1,8 +1,6 @@
 
 import ipywidgets as widgets
-from traitlets import (
-    Unicode, Int, List, observe, HasTraits, Float, Bool
-)
+from traitlets import Unicode, Int, List, observe, HasTraits, Bool
 
 import gmaps.geotraitlets as geotraitlets
 import gmaps.bounds as bounds

--- a/gmaps/tests/test_drawing.py
+++ b/gmaps/tests/test_drawing.py
@@ -259,13 +259,17 @@ class DrawingFactory(unittest.TestCase):
 
 class Line(unittest.TestCase):
 
+    def setUp(self):
+        self.start = (5.0, 10.0)
+        self.end = (20.0, 30.0)
+
     def test_start_end_kwargs(self):
         line = drawing.Line(
-            start=(5.0, 10.0),
-            end=(20.0, 30.0)
+            start=self.start,
+            end=self.end
         )
-        assert line.get_state()['start'] == (5.0, 10.0)
-        assert line.get_state()['end'] == (20.0, 30.0)
+        assert line.get_state()['start'] == self.start
+        assert line.get_state()['end'] == self.end
 
     def test_missing_start(self):
         with self.assertRaises(TypeError):
@@ -276,22 +280,39 @@ class Line(unittest.TestCase):
             drawing.Line(start=(20.0, 30.0))
 
     def test_normal_arguments(self):
-        line = drawing.Line((5.0, 10.0), (20.0, 30.0))
-        assert line.get_state()['start'] == (5.0, 10.0)
-        assert line.get_state()['end'] == (20.0, 30.0)
+        line = drawing.Line(self.start, self.end)
+        assert line.get_state()['start'] == self.start
+        assert line.get_state()['end'] == self.end
+
+    def test_defaults(self):
+        line = drawing.Line(self.start, self.end)
+        assert line.get_state()['stroke_opacity'] == 0.6
+
+    def test_set_opacity(self):
+        line = drawing.Line(self.start, self.end, stroke_opacity=0.2)
+        assert line.get_state()['stroke_opacity'] == 0.2
+
+    def test_invalid_opacity(self):
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Line(self.start, self.end, stroke_opacity=-0.2)
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Line(self.start, self.end, stroke_opacity=1.2)
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Line(self.start, self.end, stroke_opacity='not-a-float')
 
 
 class Polygon(unittest.TestCase):
 
+    def setUp(self):
+        self.path = [(10.0, 20.0), (5.0, 30.0), (-5.0, 10.0)]
+
     def test_path_kwarg(self):
-        path = [(10.0, 20.0), (5.0, 30.0), (-5.0, 10.0)]
-        polygon = drawing.Polygon(path=path)
-        assert polygon.get_state()['path'] == path
+        polygon = drawing.Polygon(path=self.path)
+        assert polygon.get_state()['path'] == self.path
 
     def test_normal_path_arg(self):
-        path = [(10.0, 20.0), (5.0, 30.0), (-5.0, 10.0)]
-        polygon = drawing.Polygon(path)
-        assert polygon.get_state()['path'] == path
+        polygon = drawing.Polygon(self.path)
+        assert polygon.get_state()['path'] == self.path
 
     def test_missing_path(self):
         with self.assertRaises(TypeError):
@@ -303,8 +324,7 @@ class Polygon(unittest.TestCase):
             drawing.Polygon(path)
 
     def test_defaults(self):
-        path = [(10.0, 20.0), (5.0, 30.0), (-5.0, 10.0)]
-        polygon = drawing.Polygon(path)
+        polygon = drawing.Polygon(self.path)
         state = polygon.get_state()
         assert state['stroke_color'] == drawing.DEFAULT_STROKE_COLOR
         assert state['stroke_weight'] == 2.0
@@ -313,9 +333,8 @@ class Polygon(unittest.TestCase):
         assert state['fill_opacity'] == 0.2
 
     def test_custom_arguments(self):
-        path = [(10.0, 20.0), (5.0, 30.0), (-5.0, 10.0)]
         polygon = drawing.Polygon(
-            path,
+            self.path,
             stroke_color=(1, 3, 5),
             stroke_weight=10.0,
             stroke_opacity=0.87,
@@ -328,6 +347,22 @@ class Polygon(unittest.TestCase):
         assert state['stroke_opacity'] == 0.87
         assert state['fill_color'] == 'rgb(7,9,11)'
         assert state['fill_opacity'] == 0.76
+
+    def test_invalid_stroke_opacity(self):
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Polygon(self.path, stroke_opacity=-0.2)
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Polygon(self.path, stroke_opacity=1.2)
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Polygon(self.path, stroke_opacity='not-a-float')
+
+    def test_invalid_fill_opacity(self):
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Polygon(self.path, fill_opacity=-0.2)
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Polygon(self.path, fill_opacity=1.2)
+        with self.assertRaises(traitlets.TraitError):
+            drawing.Polygon(self.path, fill_opacity='not-a-float')
 
 
 class PolygonOptions(unittest.TestCase):

--- a/gmaps/tests/test_geotraitlets.py
+++ b/gmaps/tests/test_geotraitlets.py
@@ -377,3 +377,15 @@ class TestOpacity(unittest.TestCase):
             x = geotraitlets.Opacity(allow_none=True, default_value=None)
         assert A().x is None
         assert A(x=0.1).x == 0.1
+
+    def test_under_min(self):
+        with self.assertRaises(traitlets.TraitError):
+            self.A(x=-1.0)
+
+    def test_over_max(self):
+        with self.assertRaises(traitlets.TraitError):
+            self.A(x=2.0)
+
+    def test_wrong_type(self):
+        with self.assertRaises(traitlets.TraitError):
+            self.A(x='not-a-float')

--- a/gmaps/tests/test_geotraitlets.py
+++ b/gmaps/tests/test_geotraitlets.py
@@ -353,3 +353,27 @@ class Point(unittest.TestCase):
         import numpy as np
         a = self.A(x=np.array([5.0, 10.0]))
         assert a.x == (5.0, 10.0)
+
+
+class TestOpacity(unittest.TestCase):
+
+    def setUp(self):
+        class A(traitlets.HasTraits):
+            x = geotraitlets.Opacity()
+        self.A = A
+
+    def test_default_value(self):
+        class A(traitlets.HasTraits):
+            x = geotraitlets.Opacity(default_value=0.5)
+        a = A()
+        assert a.x == 0.5
+
+    def test_set_value(self):
+        a = self.A(x=0.3)
+        assert a.x == 0.3
+
+    def test_allow_none(self):
+        class A(traitlets.HasTraits):
+            x = geotraitlets.Opacity(allow_none=True, default_value=None)
+        assert A().x is None
+        assert A(x=0.1).x == 0.1

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -4,9 +4,12 @@ import pytest
 
 import numpy as np
 
+import traitlets
+
 from ..marker import (
     MarkerOptions,
     Marker,
+    Symbol,
     _marker_layer_options,
     _symbol_layer_options
 )
@@ -247,3 +250,46 @@ class MarkerTest(unittest.TestCase):
         )
         assert not marker.display_info_box
         assert marker.info_box_content == 'test-content'
+
+
+class SymbolTest(unittest.TestCase):
+
+    def setUp(self):
+        self.location = (10.0, 5.0)
+
+    def test_defaults(self):
+        symbol = Symbol(self.location)
+        state = symbol.get_state()
+        assert state['fill_color'] is None
+        assert state['fill_opacity'] == 1.0
+        assert state['stroke_color'] is None
+        assert state['stroke_opacity'] == 1.0
+        assert state['scale'] == 4
+
+    def test_set_fill_opacity(self):
+        symbol = Symbol(self.location, fill_opacity=0.2)
+        assert symbol.get_state()['fill_opacity'] == 0.2
+        symbol.fill_opacity = 0.8
+        assert symbol.get_state()['fill_opacity'] == 0.8
+
+    def test_invalid_fill_opacity(self):
+        with self.assertRaises(traitlets.TraitError):
+            Symbol(self.location, fill_opacity=-0.2)
+        with self.assertRaises(traitlets.TraitError):
+            Symbol(self.location, fill_opacity=1.2)
+        with self.assertRaises(traitlets.TraitError):
+            Symbol(self.location, fill_opacity='not-a-float')
+
+    def test_set_stroke_opacity(self):
+        symbol = Symbol(self.location, stroke_opacity=0.2)
+        assert symbol.get_state()['stroke_opacity'] == 0.2
+        symbol.stroke_opacity = 0.8
+        assert symbol.get_state()['stroke_opacity'] == 0.8
+
+    def test_invalid_stroke_opacity(self):
+        with self.assertRaises(traitlets.TraitError):
+            Symbol(self.location, stroke_opacity=-0.2)
+        with self.assertRaises(traitlets.TraitError):
+            Symbol(self.location, stroke_opacity=1.2)
+        with self.assertRaises(traitlets.TraitError):
+            Symbol(self.location, stroke_opacity='not-a-float')


### PR DESCRIPTION
Prior to this PR, we were redefining opacities everywhere as a `Float(min=0.0, max=1.0)` traitlet. This centralises the definition into a single `Opacity` traitlet.

This PR should make no functional changes.