### PR TITLE
Remove deprecated data traitlet from heatmap

### DIFF
--- a/gmaps/heatmap.py
+++ b/gmaps/heatmap.py
@@ -1,6 +1,4 @@
 
-import warnings
-
 import ipywidgets as widgets
 from traitlets import (
     Float, Bool, Unicode, HasTraits, default, List, observe
@@ -51,13 +49,6 @@ _doc_snippets['options'] = """
         (100, 0, 0, 0.5).
     :type gradient: list of colors, optional
 """
-
-
-def _warn_obsolete_data():
-    warnings.warn(
-        'The "data" traitlet is deprecated, and will be '
-        'removed in jupyter-gmaps 0.8.0. '
-        'Use "locations" instead.', DeprecationWarning)
 
 
 # Mixin for options common to both heatmap and weighted heatmaps.
@@ -129,17 +120,10 @@ class Heatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     _view_name = Unicode('SimpleHeatmapLayerView').tag(sync=True)
     _model_name = Unicode('SimpleHeatmapLayerModel').tag(sync=True)
 
-    data = List()
     locations = geotraitlets.LocationArray(
         allow_none=False, minlen=1
     ).tag(sync=True)
     data_bounds = List().tag(sync=True)
-
-    @observe('data')
-    def _on_data_change(self, change):
-        data = change['new']
-        _warn_obsolete_data()
-        self.locations = data
 
     @observe('locations')
     def _calc_bounds(self, change):
@@ -192,7 +176,6 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
     _view_name = Unicode('WeightedHeatmapLayerView').tag(sync=True)
     _model_name = Unicode('WeightedHeatmapLayerModel').tag(sync=True)
 
-    data = List()
     locations = geotraitlets.LocationArray(
         allow_none=False, minlen=1
     ).tag(sync=True)
@@ -200,13 +183,6 @@ class WeightedHeatmap(GMapsWidgetMixin, widgets.Widget, _HeatmapOptionsMixin):
         allow_none=False, minlen=1
     ).tag(sync=True)
     data_bounds = List().tag(sync=True)
-
-    @observe('data')
-    def _on_data_change(self, change):
-        data = change['new']
-        _warn_obsolete_data()
-        self.locations = [point[:2] for point in data]
-        self.weights = [point[2] for point in data]
 
     @observe('locations')
     def _calc_bounds(self, change):

--- a/gmaps/tests/test_heatmap.py
+++ b/gmaps/tests/test_heatmap.py
@@ -138,15 +138,6 @@ class TestHeatmap(unittest.TestCase):
     def setUp(self):
         self.locations = [(-5.0, 5.0), (10.0, 10.0)]
 
-    def test_set_data(self):
-        heatmap = Heatmap(data=self.locations)
-        assert heatmap.locations == self.locations
-
-    def test_change_data(self):
-        heatmap = Heatmap(locations=self.locations)
-        heatmap.data = self.locations * 2
-        assert heatmap.locations == self.locations * 2
-
     def test_set_locations_np_array(self):
         import numpy as np
         heatmap = Heatmap(locations=self.locations)
@@ -173,18 +164,6 @@ class TestWeightedHeatmap(unittest.TestCase):
             (-5.0, 5.0, 0.2),
             (10.0, 10.0, 0.5),
         ]
-
-    def test_set_data(self):
-        heatmap = WeightedHeatmap(data=self.merged_location_weights)
-        assert heatmap.locations == self.locations
-        assert heatmap.weights == self.weights
-
-    def test_change_data(self):
-        heatmap = WeightedHeatmap(
-            locations=self.locations, weights=self.weights)
-        heatmap.data = self.merged_location_weights * 2
-        assert heatmap.locations == self.locations * 2
-        assert heatmap.weights == self.weights * 2
 
     def test_non_float_weights(self):
         with self.assertRaises(traitlets.TraitError):


### PR DESCRIPTION
The `data` traitlet was deprecated from the `Heatmap` and `WeightedHeatmap` widgets in PR #211. They were replaced by split out:

 - locations traitlet for the `Heatmap` widget
 - locations and weights traitlets for the `WeightedHeatmap` widget.

This PR removes the data traitlet completely.