### PR TITLE
Add tilt option to gmaps.figure

### DIFF
--- a/gmaps/figure.py
+++ b/gmaps/figure.py
@@ -139,11 +139,12 @@ def figure(
     :type zoom_level: int, optional
 
     :param tilt:
-        Tilt can be either 0 or 45 indicating the tilt angle.
-
-        45-degree imagery is only available for satellite and hybrid map types,
-        and is not available at every location at every zoom level. If 45-degree
-        imagery is not available, Google Maps will automatically fall back to 0 tilt.
+        Tilt can be either 0 or 45 indicating the tilt angle in
+        degrees.  45-degree imagery is only available for satellite
+        and hybrid map types, and is not available at every location
+        at every zoom level. For locations where 45-degree imagery is
+        not available, Google Maps will automatically fall back to 0
+        tilt.
     :type tilt: int, optional
 
     :param center:

--- a/gmaps/figure.py
+++ b/gmaps/figure.py
@@ -141,8 +141,9 @@ def figure(
     :param tilt:
         Tilt can be either 0 or 45 indicating the tilt angle.
 
-        Keep in mind that 45 degree imagery is only available for satellite and
-        hybrid map types, and is not available at every location at every zoom level.
+        45-degree imagery is only available for satellite and hybrid map types,
+        and is not available at every location at every zoom level. If 45-degree
+        imagery is not available, Google Maps will automatically fall back to 0 tilt.
     :type tilt: int, optional
 
     :param center:

--- a/gmaps/figure.py
+++ b/gmaps/figure.py
@@ -6,7 +6,7 @@ from traitlets import Unicode, Instance, default, link
 from .maps import (
     Map, InitialViewport, GMapsWidgetMixin, map_params_doc_snippets
 )
-from .geotraitlets import MapType, MouseHandling
+from .geotraitlets import MapType, MouseHandling, Tilt
 from .toolbar import Toolbar
 from .errors_box import ErrorsBox
 from ._docutils import doc_subst
@@ -40,6 +40,7 @@ class Figure(GMapsWidgetMixin, widgets.DOMWidget):
         sync=True, **widgets.widget_serialization)
     _map = Instance(Map).tag(sync=True, **widgets.widget_serialization)
     map_type = MapType('ROADMAP')
+    tilt = Tilt()
     mouse_handling = MouseHandling('COOPERATIVE')
     layout = widgets.trait_types.InstanceDict(FigureLayout).tag(
         sync=True, **widgets.widget_serialization)
@@ -50,6 +51,10 @@ class Figure(GMapsWidgetMixin, widgets.DOMWidget):
         super(Figure, self).__init__(*args, **kwargs)
         self._map.map_type = self.map_type
         link((self._map, 'map_type'), (self, 'map_type'))
+
+        self._map.tilt = self.tilt
+        link((self._map, 'tilt'), (self, 'tilt'))
+
         self._map.mouse_handling = self.mouse_handling
         link((self._map, 'mouse_handling'), (self, 'mouse_handling'))
 
@@ -109,7 +114,7 @@ class Figure(GMapsWidgetMixin, widgets.DOMWidget):
 
 @doc_subst(map_params_doc_snippets)
 def figure(
-        display_toolbar=True, display_errors=True, zoom_level=None,
+        display_toolbar=True, display_errors=True, zoom_level=None, tilt=45,
         center=None, layout=None, map_type='ROADMAP',
         mouse_handling='COOPERATIVE'):
     """
@@ -132,6 +137,13 @@ def figure(
         By default, the zoom level is chosen to fit the data passed to the
         map. If specified, you must also specify the map center.
     :type zoom_level: int, optional
+
+    :param tilt:
+        Tilt can be either 0 or 45 indicating the tilt angle.
+
+        Keep in mind that 45 degree imagery is only available for satellite and
+        hybrid map types, and is not available at every location at every zoom level.
+    :type tilt: int, optional
 
     :param center:
         Latitude-longitude pair determining the map center.
@@ -179,6 +191,7 @@ def figure(
     To have a satellite map:
 
     >>> fig = gmaps.figure(map_type='HYBRID')
+
     """  # noqa: E501
     if zoom_level is not None or center is not None:
         if zoom_level is None or center is None:
@@ -202,6 +215,6 @@ def figure(
     _errors_box = ErrorsBox() if display_errors else None
     fig = Figure(
         _map=_map, _toolbar=_toolbar, _errors_box=_errors_box,
-        layout=layout, map_type=map_type,
+        layout=layout, map_type=map_type, tilt=tilt,
         mouse_handling=mouse_handling)
     return fig

--- a/gmaps/geotraitlets.py
+++ b/gmaps/geotraitlets.py
@@ -185,6 +185,20 @@ class ZoomLevel(traitlets.Integer):
             self.error(obj, value)
 
 
+class Tilt(traitlets.Integer):
+    """
+    Integer representing a tilt degree allowed by Google Maps
+    """
+    info_text = 'tilt angle in degrees (either 0 or 45)'
+    default_value = 45
+
+    def validate(self, obj, value):
+        if value in {0, 45}:
+            return value
+        else:
+            self.error(obj, value)
+
+
 class ColorAlpha(traitlets.Union):
     """
     Trait representing a color that can be passed to Google maps.

--- a/gmaps/maps.py
+++ b/gmaps/maps.py
@@ -4,7 +4,7 @@ from traitlets import (Unicode, default, List, Tuple, Instance,
                        observe, Dict, HasTraits, Enum, Union)
 
 from .bounds import merge_longitude_bounds
-from .geotraitlets import Point, ZoomLevel, MapType, MouseHandling
+from .geotraitlets import Point, ZoomLevel, MapType, MouseHandling, Tilt
 from ._docutils import doc_subst
 from ._version import CLIENT_VERSION
 
@@ -194,6 +194,7 @@ class Map(ConfigurationMixin, GMapsWidgetMixin, widgets.DOMWidget):
     initial_viewport = InitialViewport(default_value='DATA_BOUNDS').tag(
             sync=True, to_json=_serialize_viewport)
     map_type = MapType('ROADMAP').tag(sync=True)
+    tilt = Tilt().tag(sync=True)
     mouse_handling = MouseHandling('COOPERATIVE').tag(sync=True)
 
     def add_layer(self, layer):

--- a/gmaps/tests/test_figure.py
+++ b/gmaps/tests/test_figure.py
@@ -100,6 +100,18 @@ class TestFigureFactory(unittest.TestCase):
         fig = figure(map_type='SATELLITE')
         assert fig.map_type == 'SATELLITE'
 
+    def test_0_tilt(self):
+        fig = figure(tilt=0)
+        assert fig._map.tilt == 0
+
+    def test_45_tilt(self):
+        fig = figure(tilt=45)
+        assert fig._map.tilt == 45
+
+    def test_default_tilt(self):
+        fig = figure()
+        assert fig._map.tilt == 45
+
     def test_custom_mouse_handling(self):
         fig = figure(mouse_handling='NONE')
         assert fig.mouse_handling == 'NONE'

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -91,6 +91,7 @@ export class PlainmapView extends ConfigurationMixin(widgets.DOMWidgetView) {
                 this._viewEvents(google);
 
                 this.layerViews.update(this.model.get('layers'));
+                this.map.setTilt(this.model.attributes.tilt)
 
                 // hack to force the map to redraw
                 setTimeout(() => {

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -91,7 +91,6 @@ export class PlainmapView extends ConfigurationMixin(widgets.DOMWidgetView) {
                 this._viewEvents(google);
 
                 this.layerViews.update(this.model.get('layers'));
-                this.map.setTilt(this.model.attributes.tilt)
 
                 // hack to force the map to redraw
                 setTimeout(() => {
@@ -113,7 +112,8 @@ export class PlainmapView extends ConfigurationMixin(widgets.DOMWidgetView) {
     readOptions(google) {
         const options = {
             mapTypeId: stringToMapType(google, this.model.get('map_type')),
-            gestureHandling: this.model.get('mouse_handling').toLowerCase()
+            gestureHandling: this.model.get('mouse_handling').toLowerCase(),
+            tilt: this.model.get('tilt')
         }
         return options
     }
@@ -126,6 +126,13 @@ export class PlainmapView extends ConfigurationMixin(widgets.DOMWidgetView) {
                     google, this.model.get('map_type'))
                 this.setMapOptions({ mapTypeId })
             }
+        )
+
+        this.model.on(
+          'change:tilt',
+          () => {
+            this.setMapOptions({ tilt: this.model.get('tilt') })
+          }
         )
 
         this.model.on(


### PR DESCRIPTION
[tilt](https://developers.google.com/maps/documentation/javascript/reference/3.exp/map#MapOptions.tilt) is an option provided by the Google Maps JavaScript API, but prior to this has not been exposed by this library.

![image](https://user-images.githubusercontent.com/2244895/39503641-d5625ee8-4d7b-11e8-9dd3-9e42751f6f7f.png)

Please excuse the unpolished code - I expect it will take some editing to get this feature ready for merging, but I figured the earlier I could get feedback on my overall approach, the better.

In particular I don't really know what I'm doing with traitlets, and perhaps tilt should default to None rather than 45 and the JavaScript setTilt call should only happen if tilt is specified.

Furthermore, since tilt doesn't apply to all maps types, gmaps could intelligently validate that setting tilt makes sense for the map type requested (although Google Maps itself accepts setTilt calls for all map types and ignores them if they don't apply).