### PR TITLE
Remove broken step in dev-install

### DIFF
--- a/dev-install
+++ b/dev-install
@@ -23,7 +23,6 @@ set -e
 
 cd js
 npm install
-npm run build
 cd ..
 
 pip install -e .


### PR DESCRIPTION
We used to run `npm run build` as part of the installation process.
Not only is this redundant (we build the JavaScript as part of the
next `pip install -e .`), it was also broken since the `build` script
was renamed `build:all`.

Addresses issue #255 .