### PR TITLE
Remove bootstrap dependency

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -34,7 +34,6 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
-    "bootstrap": "^3.3.7",
     "css-loader": "^0.28.1",
     "file-loader": "^0.11.2",
     "json-loader": "^0.5.4",

--- a/js/src/Drawing.js
+++ b/js/src/Drawing.js
@@ -480,7 +480,7 @@ export class DrawingControlsView extends widgets.DOMWidgetView {
     _createLayout() {
         const $container = $('<span />')
         $container
-            .addClass('btn-group')
+            .addClass('gmaps-toolbar-btn-group')
             .attr('data-toggle', 'buttons');
 
         const $disableButton = this._createModeButton(
@@ -541,7 +541,7 @@ export class DrawingControlsView extends widgets.DOMWidgetView {
     _createModeButton(icon, hoverText) {
         const $button = $('<button />')
         $button
-            .addClass('btn btn-default')
+            .addClass('gmaps-toolbar-btn')
             .attr('title', hoverText)
             .append('<i />')
             .addClass(`${icon}`)

--- a/js/src/ErrorsBox.js
+++ b/js/src/ErrorsBox.js
@@ -52,7 +52,7 @@ export class ErrorsBoxView extends widgets.DOMWidgetView {
         const errorContainer = $('<ul />').addClass('gmaps-error-box')
         this.model.get('errors').map(
             (message, ierror) =>
-                $(`<li class="well well-sm"><pre>${message}</pre></li>`)
+                $(`<li class="errors-box-well"><pre>${message}</pre></li>`)
                     .click(() => this.model.removeError(ierror))
         ).forEach(element => errorContainer.append(element))
         this.$el.empty(); // Clear the current state

--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -8,8 +8,8 @@ export class SymbolModel extends GMapsLayerModel {
     defaults() {
         return {
             ...super.defaults(),
-            _view_name: "SymbolView",
-            _model_name: "SymbolModel"
+            _view_name: 'SymbolView',
+            _model_name: 'SymbolModel'
         }
     }
 }
@@ -19,8 +19,8 @@ export class MarkerModel extends GMapsLayerModel {
     defaults() {
         return {
             ...super.defaults(),
-            _view_name: "MarkerView",
-            _model_name: "MarkerModel"
+            _view_name: 'MarkerView',
+            _model_name: 'MarkerModel'
         }
     }
 }
@@ -30,8 +30,8 @@ export class MarkerLayerModel extends GMapsLayerModel {
     defaults() {
         return {
             ...super.defaults(),
-            _view_name: "MarkerLayerView",
-            _model_name: "MarkerLayerModel"
+            _view_name: 'MarkerLayerView',
+            _model_name: 'MarkerLayerModel'
         }
     }
 
@@ -52,8 +52,8 @@ export class MarkerLayerModel extends GMapsLayerModel {
  */
 class BaseMarkerView extends widgets.WidgetView {
     render() {
-        const [lat, lng] = this.model.get("location")
-        const title = this.model.get("hover_text")
+        const [lat, lng] = this.model.get('location')
+        const title = this.model.get('hover_text')
         const styleOptions = this.getStyleOptions()
         const markerOptions = {
             position: {lat, lng},
@@ -80,12 +80,12 @@ class BaseMarkerView extends widgets.WidgetView {
     }
 
     displayInfoBox() {
-        return this.model.get("display_info_box");
+        return this.model.get('display_info_box');
     }
 
     renderInfoBox() {
         const infoBox = new google.maps.InfoWindow({
-            content: this.model.get("info_box_content")
+            content: this.model.get('info_box_content')
         });
         return infoBox ;
     }
@@ -94,7 +94,7 @@ class BaseMarkerView extends widgets.WidgetView {
         this.restoreClickable();
         if (this.displayInfoBox()) {
             this.infoBoxListener = this.marker.addListener(
-                "click",
+                'click',
                 () => { this.infoBox.open(this.mapView.map, this.marker) }
             )
         }
@@ -148,7 +148,7 @@ class BaseMarkerView extends widgets.WidgetView {
             this.model.on(`change:${nameInModel}`, callback, this)
         })
 
-        this.model.on("change:display_info_box", () => {
+        this.model.on('change:display_info_box', () => {
             this.toggleInfoBoxListener()
         }, this)
 
@@ -159,11 +159,11 @@ class BaseMarkerView extends widgets.WidgetView {
 export class SymbolView extends BaseMarkerView {
 
     getStyleOptions() {
-        const fillColor = this.model.get("fill_color")
-        const strokeColor = this.model.get("stroke_color")
-        const fillOpacity = this.model.get("fill_opacity")
-        const strokeOpacity = this.model.get("stroke_opacity")
-        const scale = this.model.get("scale")
+        const fillColor = this.model.get('fill_color')
+        const strokeColor = this.model.get('stroke_color')
+        const fillOpacity = this.model.get('fill_opacity')
+        const strokeOpacity = this.model.get('stroke_opacity')
+        const scale = this.model.get('scale')
         return {
             icon: {
                 path: google.maps.SymbolPath.CIRCLE,
@@ -200,7 +200,7 @@ export class MarkerView extends BaseMarkerView {
 
     getStyleOptions() {
         this.modelEvents()
-        const label = this.model.get("label")
+        const label = this.model.get('label')
         return { label }
     }
 
@@ -230,7 +230,7 @@ export class MarkerLayerView extends GMapsLayerView {
 
     render() {
         this.markerViews = new widgets.ViewList(this.addMarker, null, this)
-        this.markerViews.update(this.model.get("markers"))
+        this.markerViews.update(this.model.get('markers'))
     }
 
     // No need to do anything here since the markers are added

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -49,7 +49,7 @@ export class ToolbarView extends widgets.DOMWidgetView {
 
         const $savingNotification = $("<button />")
         $savingNotification
-            .addClass("notification_widget btn btn-xs navbar-btn")
+            .addClass("notification_widget btn")
             .addClass("warning notification-widget")
             .html("<span>Downloading</span>")
             .hide();

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -47,10 +47,9 @@ export class ToolbarView extends widgets.DOMWidgetView {
         $notificationArea
             .addClass("notification-area");
 
-        const $savingNotification = $("<button />")
+        const $savingNotification = $("<span />")
         $savingNotification
-            .addClass("notification_widget btn")
-            .addClass("warning notification-widget")
+            .addClass("notification-widget")
             .html("<span>Downloading</span>")
             .hide();
 

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -8,8 +8,8 @@ export class ToolbarModel extends widgets.DOMWidgetModel {
         return {
             ...super.defaults(),
             ...defaultAttributes,
-            _model_name: "ToolbarModel",
-            _view_name: "ToolbarView",
+            _model_name: 'ToolbarModel',
+            _view_name: 'ToolbarView',
             layer_controls: [],
         }
     }
@@ -25,42 +25,42 @@ export class ToolbarView extends widgets.DOMWidgetView {
     render() {
         this.$el.addClass('gmaps-toolbar-container')
 
-        const $toolbar = $("<div />");
+        const $toolbar = $('<div />');
         $toolbar
-            .addClass("gmaps-toolbar toolbar-inner navbar-inner");
+            .addClass('gmaps-toolbar toolbar-inner navbar-inner');
 
-        const $toolbarContainer = $("<div />")
+        const $toolbarContainer = $('<div />')
         $toolbarContainer
-            .addClass("toolbar");
+            .addClass('toolbar');
 
-        const $saveButton = $("<button />")
+        const $saveButton = $('<button />')
         $saveButton
-            .addClass("btn btn-default")
-            .attr("title", "Download the map as PNG")
-            .append("<i />")
-            .addClass("fa fa-download");
+            .addClass('btn btn-default')
+            .attr('title', 'Download the map as PNG')
+            .append('<i />')
+            .addClass('fa fa-download');
 
         this.$additionalControlsContainer = $('<div />')
         this.$additionalControlsContainer.addClass('additional-controls-container')
 
-        const $notificationArea = $("<span />");
+        const $notificationArea = $('<span />');
         $notificationArea
-            .addClass("notification-area");
+            .addClass('notification-area');
 
-        const $savingNotification = $("<span />")
+        const $savingNotification = $('<span />')
         $savingNotification
-            .addClass("notification-widget")
-            .html("<span>Downloading</span>")
+            .addClass('notification-widget')
+            .html('<span>Downloading</span>')
             .hide();
 
         $saveButton
             .click((event) => {
                 event.preventDefault();
-                $saveButton.prop("disabled", true)
+                $saveButton.prop('disabled', true)
                 $savingNotification.show()
                 if (this.savePngCallback) {
                     this.savePngCallback().then(() => {
-                        $saveButton.prop("disabled", false)
+                        $saveButton.prop('disabled', false)
                         $savingNotification.hide();
                     });
                 };

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -35,7 +35,7 @@ export class ToolbarView extends widgets.DOMWidgetView {
 
         const $saveButton = $('<button />')
         $saveButton
-            .addClass('btn btn-default')
+            .addClass('gmaps-toolbar-btn')
             .attr('title', 'Download the map as PNG')
             .append('<i />')
             .addClass('fa fa-download');

--- a/js/src/embed.js
+++ b/js/src/embed.js
@@ -6,5 +6,4 @@
 
 export * from './index'
 
-require('bootstrap/dist/css/bootstrap.min.css')  // Ensure bootstrap is present when embedding
 require('./jupyter-gmaps-embed.less')

--- a/js/src/jupyter-gmaps-embed.less
+++ b/js/src/jupyter-gmaps-embed.less
@@ -1,5 +1,5 @@
 
 .gmaps-figure {
-  margin-top: 1em;
-  margin-bottom: 1em;
+    margin-top: 1em;
+    margin-bottom: 1em;
 }

--- a/js/src/jupyter-gmaps-embed.less
+++ b/js/src/jupyter-gmaps-embed.less
@@ -2,17 +2,4 @@
 .gmaps-figure {
   margin-top: 1em;
   margin-bottom: 1em;
-
-  .toolbar {
-    .navbar-btn.btn-xs {
-      margin-top: 0;
-      margin-bottom: 0;
-    }
-
-    .navbar-btn.btn-xs.warning {
-      background-color: #f0ad4e;
-      border-color: #eea236;
-      color: #fff;
-    }
-  }
 }

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -112,16 +112,22 @@
   pre {
     padding-top: 5px;
     padding-bottom: 5px;
+    word-break: normal;
   }
 
   .well {
     cursor: pointer;
     margin-bottom: 10px;
+    background-color: #f5f5f5;
+    border: 1px solid #e3e3e3;
+    border-radius: 1px;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+
+    &.well-sm {
+      padding: 6px;
+    }
   }
 
-  .well.well-sm {
-      padding: 6px;
-  }
 }
 
 

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -109,22 +109,17 @@
   margin-top: 2px;
   margin-bottom: 0px;
 
-  pre {
-    padding-top: 5px;
-    padding-bottom: 5px;
-    word-break: normal;
-  }
-
-  .well {
+  .errors-box-well {
     cursor: pointer;
     margin-bottom: 10px;
     background-color: #f5f5f5;
     border: 1px solid #e3e3e3;
     border-radius: 1px;
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+    padding: 6px;
 
-    &.well-sm {
-      padding: 6px;
+    pre {
+      word-break: normal;
     }
   }
 

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -45,6 +45,7 @@
     border-radius: 4px;
     cursor: pointer;
     -webkit-appearance: none;
+    font-size: 13px;
 
     &.active, &:active {
         outline: none;

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -43,6 +43,13 @@
     padding-bottom: 2px;
     border-radius: 4px;
     -webkit-appearance: none;
+
+    &.active {
+        outline: none;
+        background-color: #e6e6e6;
+        border-color: #adadad;
+        box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+    }
   }
 
   .notification-area {

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -25,13 +25,13 @@
         }
 
         & > .gmaps-toolbar-btn:first-child {
-            border-top-left-radius: 4px;
-            border-bottom-left-radius: 4px;
+            border-top-left-radius: 2px;
+            border-bottom-left-radius: 2px;
         }
 
         & > .gmaps-toolbar-btn:last-child {
-            border-top-right-radius: 4px;
-            border-bottom-right-radius: 4px;
+            border-top-right-radius: 2px;
+            border-bottom-right-radius: 2px;
         }
     }
 
@@ -42,7 +42,7 @@
         padding-right: 8px;
         padding-top: 2px;
         padding-bottom: 2px;
-        border-radius: 4px;
+        border-radius: 2px;
         cursor: pointer;
         -webkit-appearance: none;
         font-size: 13px;
@@ -80,7 +80,7 @@
         font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
         font-size: 12px;
         line-height: 1.5;
-        border-radius: 4px;
+        border-radius: 2px;
         padding-left: 9px;
         padding-right: 9px;
         padding-top: 4px;
@@ -89,7 +89,6 @@
         background-color: #f0ad4e;
         border-color: #eea236;
         color: #fff;
-        border-radius: 4px;
     }
 
     .additional-controls-container {
@@ -117,7 +116,7 @@
         margin-bottom: 10px;
         background-color: #f5f5f5;
         border: 1px solid #e3e3e3;
-        border-radius: 1px;
+        border-radius: 2px;
         box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
         padding: 6px;
 

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -14,6 +14,26 @@
     margin-right: 0px;
   }
 
+  .btn-group {
+      margin-top: 0;
+      margin-left: 5px;
+
+      & > .btn {
+          margin-left: -1px;
+          border-radius: 0;
+      }
+
+      & > .btn:first-child {
+          border-top-left-radius: 4px;
+          border-bottom-left-radius: 4px;
+      }
+
+      & > .btn:last-child {
+          border-top-right-radius: 4px;
+          border-bottom-right-radius: 4px;
+      }
+  }
+
   .btn {
     height: 26px;
     width: 30px;
@@ -21,6 +41,8 @@
     padding-right: 8px;
     padding-top: 2px;
     padding-bottom: 2px;
+    border-radius: 4px;
+    -webkit-appearance: none;
   }
 
   .notification-area {
@@ -94,6 +116,7 @@
   font-variant: normal;
   text-transform: none;
   line-height: 1;
+  vertical-align: top;
 
   /* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -43,6 +43,7 @@
     padding-top: 2px;
     padding-bottom: 2px;
     border-radius: 4px;
+    cursor: pointer;
     -webkit-appearance: none;
 
     &.active, &:active {
@@ -68,9 +69,17 @@
   .notification-widget {
     height: 26px;
     width: auto;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    margin-top: 0;
+    margin-bottom: 0;
     margin-right: 0px;
+    font-size: 12px;
+    line-height: 1.5;
+
+    &.warning {
+      background-color: #f0ad4e;
+      border-color: #eea236;
+      color: #fff;
+    }
   }
 
   .additional-controls-container {

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -69,17 +69,23 @@
   .notification-widget {
     height: 26px;
     width: auto;
+    display: inline-block;
+    box-sizing: border-box;
     margin-top: 0;
     margin-bottom: 0;
     margin-right: 0px;
     font-size: 12px;
     line-height: 1.5;
+    border-radius: 4px;
+    padding-left: 9px;
+    padding-right: 9px;
+    padding-top: 4px;
+    padding-bottom: 1px;
 
-    &.warning {
-      background-color: #f0ad4e;
-      border-color: #eea236;
-      color: #fff;
-    }
+    background-color: #f0ad4e;
+    border-color: #eea236;
+    color: #fff;
+    border-radius: 4px;
   }
 
   .additional-controls-container {

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -14,28 +14,28 @@
     margin-right: 0px;
   }
 
-  .btn-group {
+  .gmaps-toolbar-btn-group {
       margin-top: 0;
       margin-left: 5px;
       vertical-align: top;
 
-      & > .btn {
+      & > .gmaps-toolbar-btn {
           margin-left: -1px;
           border-radius: 0;
       }
 
-      & > .btn:first-child {
+      & > .gmaps-toolbar-btn:first-child {
           border-top-left-radius: 4px;
           border-bottom-left-radius: 4px;
       }
 
-      & > .btn:last-child {
+      & > .gmaps-toolbar-btn:last-child {
           border-top-right-radius: 4px;
           border-bottom-right-radius: 4px;
       }
   }
 
-  .btn {
+  .gmaps-toolbar-btn {
     height: 26px;
     width: 30px;
     padding-left: 8px;

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -46,6 +46,8 @@
     cursor: pointer;
     -webkit-appearance: none;
     font-size: 13px;
+    background-color: white;
+    border: 1px solid #ccc;
 
     &.active, &:active {
         outline: none;

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -17,6 +17,7 @@
   .btn-group {
       margin-top: 0;
       margin-left: 5px;
+      vertical-align: top;
 
       & > .btn {
           margin-left: -1px;

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -44,11 +44,16 @@
     border-radius: 4px;
     -webkit-appearance: none;
 
-    &.active {
+    &.active, &:active {
         outline: none;
         background-color: #e6e6e6;
         border-color: #adadad;
         box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+    }
+
+    &:hover {
+        background-color: #e6e6e6;
+        border-color: #adadad;
     }
   }
 

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -77,6 +77,7 @@
     margin-top: 0;
     margin-bottom: 0;
     margin-right: 0px;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 12px;
     line-height: 1.5;
     border-radius: 4px;
@@ -121,6 +122,8 @@
     padding: 6px;
 
     pre {
+      margin: 0;
+      white-space: pre-wrap;
       word-break: normal;
     }
   }

--- a/js/src/jupyter-gmaps.less
+++ b/js/src/jupyter-gmaps.less
@@ -5,101 +5,101 @@
 
 .gmaps-toolbar {
 
-  margin-top: 2px;
-  margin-bottom: 5px;
+    margin-top: 2px;
+    margin-bottom: 5px;
 
-  .toolbar {
-    width: 100%;
-    margin-left: 0px;
-    margin-right: 0px;
-  }
-
-  .gmaps-toolbar-btn-group {
-      margin-top: 0;
-      margin-left: 5px;
-      vertical-align: top;
-
-      & > .gmaps-toolbar-btn {
-          margin-left: -1px;
-          border-radius: 0;
-      }
-
-      & > .gmaps-toolbar-btn:first-child {
-          border-top-left-radius: 4px;
-          border-bottom-left-radius: 4px;
-      }
-
-      & > .gmaps-toolbar-btn:last-child {
-          border-top-right-radius: 4px;
-          border-bottom-right-radius: 4px;
-      }
-  }
-
-  .gmaps-toolbar-btn {
-    height: 26px;
-    width: 30px;
-    padding-left: 8px;
-    padding-right: 8px;
-    padding-top: 2px;
-    padding-bottom: 2px;
-    border-radius: 4px;
-    cursor: pointer;
-    -webkit-appearance: none;
-    font-size: 13px;
-    background-color: white;
-    border: 1px solid #ccc;
-
-    &.active, &:active {
-        outline: none;
-        background-color: #e6e6e6;
-        border-color: #adadad;
-        box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+    .toolbar {
+        width: 100%;
+        margin-left: 0px;
+        margin-right: 0px;
     }
 
-    &:hover {
-        background-color: #e6e6e6;
-        border-color: #adadad;
-    }
-  }
+    .gmaps-toolbar-btn-group {
+        margin-top: 0;
+        margin-left: 5px;
+        vertical-align: top;
 
-  .notification-area {
-    height: 26px;
-    float: right;
-    z-index: 10;
-    width: auto;
-  }
+        & > .gmaps-toolbar-btn {
+            margin-left: -1px;
+            border-radius: 0;
+        }
 
-  .notification-widget {
-    height: 26px;
-    width: auto;
-    display: inline-block;
-    box-sizing: border-box;
-    margin-top: 0;
-    margin-bottom: 0;
-    margin-right: 0px;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 12px;
-    line-height: 1.5;
-    border-radius: 4px;
-    padding-left: 9px;
-    padding-right: 9px;
-    padding-top: 4px;
-    padding-bottom: 1px;
+        & > .gmaps-toolbar-btn:first-child {
+            border-top-left-radius: 4px;
+            border-bottom-left-radius: 4px;
+        }
 
-    background-color: #f0ad4e;
-    border-color: #eea236;
-    color: #fff;
-    border-radius: 4px;
-  }
-
-  .additional-controls-container {
-    display: inline;
-
-    .additional-controls {
-      display: inline;
+        & > .gmaps-toolbar-btn:last-child {
+            border-top-right-radius: 4px;
+            border-bottom-right-radius: 4px;
+        }
     }
 
-  }
+    .gmaps-toolbar-btn {
+        height: 26px;
+        width: 30px;
+        padding-left: 8px;
+        padding-right: 8px;
+        padding-top: 2px;
+        padding-bottom: 2px;
+        border-radius: 4px;
+        cursor: pointer;
+        -webkit-appearance: none;
+        font-size: 13px;
+        background-color: white;
+        border: 1px solid #ccc;
+
+        &.active, &:active {
+            outline: none;
+            background-color: #e6e6e6;
+            border-color: #adadad;
+            box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+        }
+
+        &:hover {
+            background-color: #e6e6e6;
+            border-color: #adadad;
+        }
+    }
+
+    .notification-area {
+        height: 26px;
+        float: right;
+        z-index: 10;
+        width: auto;
+    }
+
+    .notification-widget {
+        height: 26px;
+        width: auto;
+        display: inline-block;
+        box-sizing: border-box;
+        margin-top: 0;
+        margin-bottom: 0;
+        margin-right: 0px;
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-size: 12px;
+        line-height: 1.5;
+        border-radius: 4px;
+        padding-left: 9px;
+        padding-right: 9px;
+        padding-top: 4px;
+        padding-bottom: 1px;
+
+        background-color: #f0ad4e;
+        border-color: #eea236;
+        color: #fff;
+        border-radius: 4px;
+    }
+
+    .additional-controls-container {
+        display: inline;
+
+        .additional-controls {
+            display: inline;
+        }
+
+    }
 
 }
 
@@ -108,61 +108,61 @@
 }
 
 .gmaps-error-box {
-  padding-left: 0px;
-  margin-top: 2px;
-  margin-bottom: 0px;
+    padding-left: 0px;
+    margin-top: 2px;
+    margin-bottom: 0px;
 
-  .errors-box-well {
-    cursor: pointer;
-    margin-bottom: 10px;
-    background-color: #f5f5f5;
-    border: 1px solid #e3e3e3;
-    border-radius: 1px;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-    padding: 6px;
+    .errors-box-well {
+        cursor: pointer;
+        margin-bottom: 10px;
+        background-color: #f5f5f5;
+        border: 1px solid #e3e3e3;
+        border-radius: 1px;
+        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+        padding: 6px;
 
-    pre {
-      margin: 0;
-      white-space: pre-wrap;
-      word-break: normal;
+        pre {
+            margin: 0;
+            white-space: pre-wrap;
+            word-break: normal;
+        }
     }
-  }
 
 }
 
 
 @font-face {
-  font-family: 'gmaps-icon-font';
-  src:  url('fonts/gmaps-icon-font.eot?khz269');
-  src:  url('fonts/gmaps-icon-font.eot?khz269#iefix') format('embedded-opentype'),
-  url('fonts/gmaps-icon-font.ttf?khz269') format('truetype'),
-  url('fonts/gmaps-icon-font.woff?khz269') format('woff'),
-  url('fonts/gmaps-icon-font.svg?khz269#icomoon') format('svg');
-  font-weight: normal;
-  font-style: normal;
+    font-family: 'gmaps-icon-font';
+    src:  url('fonts/gmaps-icon-font.eot?khz269');
+    src:  url('fonts/gmaps-icon-font.eot?khz269#iefix') format('embedded-opentype'),
+          url('fonts/gmaps-icon-font.ttf?khz269') format('truetype'),
+          url('fonts/gmaps-icon-font.woff?khz269') format('woff'),
+          url('fonts/gmaps-icon-font.svg?khz269#icomoon') format('svg');
+    font-weight: normal;
+    font-style: normal;
 }
 
 .gmaps-icon {
-  /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: 'gmaps-icon-font' !important;
-  speak: none;
-  font-style: normal;
-  font-weight: normal;
-  font-variant: normal;
-  text-transform: none;
-  line-height: 1;
-  vertical-align: top;
+    /* use !important to prevent issues with browser extensions that change fonts */
+    font-family: 'gmaps-icon-font' !important;
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    vertical-align: top;
 
-  /* Better Font Rendering =========== */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    /* Better Font Rendering =========== */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 
-  &.line:before {
-    content: "\e900";
-  }
+    &.line:before {
+        content: "\e900";
+    }
 
-  &.polygon:before {
-    content: "\e901";
-  }
+    &.polygon:before {
+        content: "\e901";
+    }
 }
 

--- a/js/src/labplugin.js
+++ b/js/src/labplugin.js
@@ -1,4 +1,4 @@
-import * as gmaps from '../dist/index';
+import * as gmaps from './index';
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
 export default {

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -3,15 +3,15 @@ var version = require('./package.json').version;
 // Custom webpack loaders are generally the same for all webpack bundles, hence
 // stored in a separate local variable.
 var loaders = [
-    { test: /\.css$/, loader: "style-loader!css-loader" },
-    { test: /\.less$/, loader: "style-loader!css-loader!less-loader" },
+    { test: /\.css$/, loader: 'style-loader!css-loader' },
+    { test: /\.less$/, loader: 'style-loader!css-loader!less-loader' },
     { test: /\.json$/, loader: 'json-loader' },
     { test: /\.js$/, loader: 'babel-loader', query: {presets: ['es2015', 'stage-0']}, exclude: /node_modules/ },
-    { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url-loader?limit=10000&mimetype=application/octet-stream" },
-    { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url-loader?limit=10000&mimetype=image/svg+xml" },
-    { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url-loader?limit=10000&mimetype=application/font-woff" },
-    { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url-loader?limit=10000&mimetype=application/font-woff" },
-    { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file-loader" },
+    { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+    { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=image/svg+xml' },
+    { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
+    { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
+    { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'file-loader' },
 ];
 
 


### PR DESCRIPTION
The dependency on Twitter Bootstrap makes reasoning about styles unnecessarily complicated and introduces unexpected side-effects, like issue #265.

We should port the styles we need and get rid of the dependency.

---

Left to do:

- [x] Fix the hover style of buttons
- [x] Fix styling of the notification area
- [x] Fix styling of errors box
- [x] Check the styles of the embed bundle still work
- [x] Check on a variety of browsers
- [x] Consider removing rounded corners of buttons
- [x] Consistent indentation in `.less` files
