### PR TITLE
Update release tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -160,15 +160,14 @@ def update_release_notes(version, new_lines):
 
 
 def get_release_notes(version):
-    version_info = semver.parse_version_info(version)
-    version_string = semver.format_version(*version_info)
-    underline = '=' * len('Version {}'.format(version_string))
+    version = normalize_version(version)
+    underline = '=' * len('Version {}'.format(version))
     initial_message = RELEASE_NOTES_TEMPLATE.format(
-        version_string=version_string, underline=underline)
+        version_string=version, underline=underline)
     lines = open_editor(initial_message)
     non_commented_lines = [line for line in lines if not line.startswith('#')]
     changelog = ''.join(non_commented_lines)
-    if version_string in changelog:
+    if version in changelog:
         if not non_commented_lines[-1].isspace():
             non_commented_lines.append('\n')
         return non_commented_lines
@@ -177,21 +176,19 @@ def get_release_notes(version):
 
 
 def set_pyversion(version):
-    version_info = semver.parse_version_info(version)
-    version_string = semver.format_version(*version_info)
+    version = normalize_version(version)
     with open(os.path.join(GMAPS_DIR, 'gmaps', '_version.py'), 'w') as f:
-        f.write(VERSION_TEMPLATE.format(version_string=version_string))
+        f.write(VERSION_TEMPLATE.format(version_string=version))
 
 
 def set_jsversion(version):
-    version_info = semver.parse_version_info(version)
-    version_string = semver.format_version(*version_info)
+    version = normalize_version(version)
     package_json_path = os.path.join(GMAPS_DIR, 'js', 'package.json')
     with open(package_json_path) as f:
         package_json = f.readlines()
     for iline, line in enumerate(package_json):
         if '"version"' in line:
-            package_json[iline] = '  "version": "{}",\n'.format(version_string)
+            package_json[iline] = '  "version": "{}",\n'.format(version)
     with open(package_json_path, 'w') as f:
         f.writelines(package_json)
 
@@ -255,3 +252,9 @@ def replace_line(lines, regexp, new_line):
     updated_lines = lines[:]
     updated_lines[iline] = new_line
     return updated_lines
+
+
+def normalize_version(version):
+    version_info = semver.parse_version_info(version)
+    version_string = str(version_info)
+    return version_string

--- a/tasks.py
+++ b/tasks.py
@@ -41,7 +41,7 @@ def prerelease(ctx, version):
     '''
     set_pyversion(version)
     set_jsversion(version)
-    run('python setup.py sdist upload')
+    release_python_sdist()
     os.chdir(os.path.join(GMAPS_DIR, 'js'))
     try:
         run('npm publish')
@@ -75,7 +75,7 @@ def release(ctx, version):
     run('git commit -m "Add release notes for version {}"'.format(version))
     set_pyversion(version)
     set_jsversion(version)
-    run('python setup.py sdist bdist upload')
+    release_python_sdist()
     os.chdir(os.path.join(GMAPS_DIR, 'js'))
     try:
         run('npm publish')
@@ -157,6 +157,12 @@ def update_release_notes(version, new_lines):
     ] + new_lines + list(current_release_notes_lines)
     with open(release_notes_path, 'w') as f:
         f.writelines(new_release_notes_lines)
+
+
+def release_python_sdist():
+    run('rm dist/*')
+    run('python setup.py sdist')
+    run('twine upload dist/*')
 
 
 def get_release_notes(version):


### PR DESCRIPTION
This PR:
- updates the release tasks to work against the new semver API
- uses twine to upload, rather than `python setup.py upload`.