### PR TITLE
Correctly propagate defaults for symbols to the client

### DIFF
--- a/js/src/Marker.js
+++ b/js/src/Marker.js
@@ -9,7 +9,10 @@ export class SymbolModel extends GMapsLayerModel {
         return {
             ...super.defaults(),
             _view_name: 'SymbolView',
-            _model_name: 'SymbolModel'
+            _model_name: 'SymbolModel',
+            fill_opacity: 1.0,
+            stroke_opacity: 1.0,
+            scale: 4
         }
     }
 }


### PR DESCRIPTION
Prior to this PR, there was a mismatch between symbol defaults in the Python side and the client. This meant that using the default values of `fill_opacity`, `scale` and `stroke_opacity` Python-side lead to unexpected behaviour when embedding (even if the default values were explicitly specified).

Reported in issue #275 .