### PR TITLE
Formatting fix in docs

### DIFF
--- a/docs/source/app_tutorial.rst
+++ b/docs/source/app_tutorial.rst
@@ -380,8 +380,8 @@ This is the entire code listing::
 
 .. image:: _images/update-symbols-with-checkboxes.png
 
- We used the :class:`gmaps.Markers` class to represent the symbol layer,
- rather than the :func:`gmaps.symbol_layer` factory function. The
- `Markers` class is easier to manipulate, since it just takes a list
- of symbols. The disadvantage is that we had to construct the symbols
- independently.
+We used the :class:`gmaps.Markers` class to represent the symbol layer,
+rather than the :func:`gmaps.symbol_layer` factory function. The
+`Markers` class is easier to manipulate, since it just takes a list
+of symbols. The disadvantage is that we had to construct the symbols
+independently.


### PR DESCRIPTION
The last paragraph of the 'building applications' tutorial did not render. Now fixed.