### PR TITLE
Support empty marker and symbol layer

### DIFF
--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -5,7 +5,7 @@ from traitlets import Unicode, Int, List, observe, HasTraits, Bool
 import gmaps.geotraitlets as geotraitlets
 import gmaps.bounds as bounds
 
-from .maps import DEFAULT_CENTER, GMapsWidgetMixin
+from .maps import DEFAULT_CENTER, DEFAULT_BOUNDS, GMapsWidgetMixin
 from .locations import locations_to_list
 from .options import merge_option_dicts, is_atomic, is_color_atomic
 from ._docutils import doc_subst
@@ -218,25 +218,28 @@ class Markers(GMapsWidgetMixin, widgets.Widget):
     >>> marker_layer.markers[0].label = 'C'  # markers[0] is a Marker
     >>> marker_layer.markers[0].scale = 5    # markers[0] is a Symbol
     """
-    has_bounds = True
     _view_name = Unicode('MarkerLayerView').tag(sync=True)
     _model_name = Unicode('MarkerLayerModel').tag(sync=True)
 
-    markers = List(minlen=1).tag(sync=True,  **widgets.widget_serialization)
+    markers = List().tag(sync=True,  **widgets.widget_serialization)
     data_bounds = List().tag(sync=True)
 
     @observe('markers')
     def _calc_bounds(self, change):
         markers = change['new']
-        locations = [marker.location for marker in markers]
-        latitudes = [location[0] for location in locations]
-        longitudes = [location[1] for location in locations]
-        min_latitude, max_latitude = bounds.latitude_bounds(latitudes)
-        min_longitude, max_longitude = bounds.longitude_bounds(longitudes)
-        self.data_bounds = [
-            (min_latitude, min_longitude),
-            (max_latitude, max_longitude)
-        ]
+        if markers:
+            locations = [marker.location for marker in markers]
+            latitudes = [location[0] for location in locations]
+            longitudes = [location[1] for location in locations]
+            min_latitude, max_latitude = bounds.latitude_bounds(latitudes)
+            min_longitude, max_longitude = bounds.longitude_bounds(longitudes)
+            self.data_bounds = [
+                (min_latitude, min_longitude),
+                (max_latitude, max_longitude)
+            ]
+            self.has_bounds = True
+        else:
+            self.has_bounds = False
 
 
 def _info_box_option_lists(number_markers, info_box_content, display_info_box):

--- a/gmaps/marker.py
+++ b/gmaps/marker.py
@@ -5,7 +5,7 @@ from traitlets import Unicode, Int, List, observe, HasTraits, Bool
 import gmaps.geotraitlets as geotraitlets
 import gmaps.bounds as bounds
 
-from .maps import DEFAULT_CENTER, DEFAULT_BOUNDS, GMapsWidgetMixin
+from .maps import DEFAULT_CENTER, GMapsWidgetMixin
 from .locations import locations_to_list
 from .options import merge_option_dicts, is_atomic, is_color_atomic
 from ._docutils import doc_subst

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -140,6 +140,10 @@ class SymbolLayer(unittest.TestCase):
         new_options.update(options)
         return new_options
 
+    def test_locations(self):
+        symbols = symbol_layer(self.locations)
+        assert [symbol.location for symbol in symbols.markers] == self.locations
+
     def test_stroke_color_atomic_text(self):
         options = self._add_default_options(stroke_color="red")
         symbols = symbol_layer(self.locations, **options)

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -33,7 +33,8 @@ class MarkerLayer(unittest.TestCase):
 
     def test_locations(self):
         markers = marker_layer(self.locations)
-        assert [marker.location for marker in markers.markers] == self.locations
+        locations = [marker.location for marker in markers.markers]
+        assert locations == self.locations
 
     def test_hover_text_atomic(self):
         options = self._add_default_options(hover_text="test-text")
@@ -141,7 +142,8 @@ class SymbolLayer(unittest.TestCase):
 
     def test_locations(self):
         symbols = symbol_layer(self.locations)
-        assert [symbol.location for symbol in symbols.markers] == self.locations
+        locations = [symbol.location for symbol in symbols.markers]
+        assert locations == self.locations
 
     def test_empty_locations(self):
         symbols = symbol_layer([])
@@ -198,7 +200,9 @@ class SymbolLayer(unittest.TestCase):
         options = self._add_default_options(
             info_box_content=test_content, display_info_box=True)
         symbols = symbol_layer(self.locations, **options)
-        content_options = [symbol.info_box_content for symbol in symbols.markers]
+        content_options = [
+            symbol.info_box_content for symbol in symbols.markers
+        ]
         assert content_options == test_content
 
     def test_infobox_default_display_lists(self):

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -144,11 +144,19 @@ class SymbolLayer(unittest.TestCase):
         symbols = symbol_layer(self.locations)
         assert [symbol.location for symbol in symbols.markers] == self.locations
 
+    def test_empty_locations(self):
+        symbols = symbol_layer([])
+        assert symbols.markers == []
+
     def test_stroke_color_atomic_text(self):
         options = self._add_default_options(stroke_color="red")
         symbols = symbol_layer(self.locations, **options)
         for symbol in symbols.markers:
             assert symbol.stroke_color == "red"
+
+    def test_empty_locations_stroke_color(self):
+        symbols = symbol_layer([], stroke_color="red")
+        assert symbols.markers == []
 
     def test_stroke_color_atomic_tuple(self):
         color = (10, 10, 10, 0.5)

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -11,7 +11,6 @@ from ..marker import (
     Marker,
     Markers,
     Symbol,
-    _marker_layer_options,
     _symbol_layer_options,
     marker_layer
 )
@@ -39,24 +38,24 @@ class MarkerLayer(unittest.TestCase):
 
     def test_hover_text_atomic(self):
         options = self._add_default_options(hover_text="test-text")
-        marker_options = _marker_layer_options(self.locations, **options)
-        for options in marker_options:
-            assert options["hover_text"] == "test-text"
+        markers = marker_layer(self.locations, **options)
+        for marker in markers.markers:
+            assert marker.hover_text == "test-text"
 
     def test_hover_text_lists(self):
         options = self._add_default_options(hover_text=["t1", "t2"])
-        marker_options = _marker_layer_options(self.locations, **options)
-        hover_texts = [opts["hover_text"] for opts in marker_options]
-        assert tuple(hover_texts) == ("t1", "t2")
+        markers = marker_layer(self.locations, **options)
+        hover_texts = [marker.hover_text for marker in markers.markers]
+        assert hover_texts == ["t1", "t2"]
 
     def test_infobox_content_atomic(self):
         test_content = "<h3>test-html-infobox</h3>"
         options = self._add_default_options(
             info_box_content=test_content, display_info_box=True)
-        marker_options = _marker_layer_options(self.locations, **options)
-        for options in marker_options:
-            assert options["info_box_content"] == test_content
-            assert options["display_info_box"]
+        markers = marker_layer(self.locations, **options)
+        for marker in markers.markers:
+            assert marker.info_box_content == test_content
+            assert marker.display_info_box
 
     def test_infobox_content_lists(self):
         test_content = ["<h1>h1</h1>", "<h2>h2</h2>"]
@@ -64,31 +63,32 @@ class MarkerLayer(unittest.TestCase):
         options = self._add_default_options(
             info_box_content=test_content,
             display_info_box=test_display_info_box)
-        marker_options = _marker_layer_options(self.locations, **options)
-        info_contents = [opts["info_box_content"] for opts in marker_options]
-        display_infos = [opts["display_info_box"] for opts in marker_options]
+        markers = marker_layer(self.locations, **options)
+        info_contents = [marker.info_box_content for marker in markers.markers]
+        display_infos = [marker.display_info_box for marker in markers.markers]
         assert tuple(info_contents) == tuple(test_content)
         assert tuple(display_infos) == tuple(test_display_info_box)
 
     def test_infobox_default_display(self):
         test_content = "test-content"
         options = self._add_default_options(info_box_content=test_content)
-        marker_options = _marker_layer_options(self.locations, **options)
-        for options in marker_options:
-            assert options["display_info_box"]
+        markers = marker_layer(self.locations, **options)
+        for marker in markers.markers:
+            assert marker.info_box_content == "test-content"
+            assert marker.display_info_box
 
     def test_infobox_default_display_lists(self):
         test_content = ["1", None]
         options = self._add_default_options(info_box_content=test_content)
-        marker_options = _marker_layer_options(self.locations, **options)
-        display_infos = [opts["display_info_box"] for opts in marker_options]
+        markers = marker_layer(self.locations, **options)
+        display_infos = [marker.display_info_box for marker in markers.markers]
         assert tuple(display_infos) == (True, False)
 
     def test_locations_array(self):
         locations_array = np.array(self.locations)
         options = self._add_default_options()
-        marker_options = _marker_layer_options(locations_array, **options)
-        locations = [opts["location"] for opts in marker_options]
+        markers = marker_layer(locations_array, **options)
+        locations = [marker.location for marker in markers.markers]
         assert locations == self.locations
 
     def test_locations_pandas_df(self):
@@ -96,8 +96,8 @@ class MarkerLayer(unittest.TestCase):
         df = pd.DataFrame.from_records(
             self.locations, columns=["latitude", "longitude"])
         options = self._add_default_options()
-        marker_options = _marker_layer_options(df, **options)
-        locations = [opts["location"] for opts in marker_options]
+        markers = marker_layer(df, **options)
+        locations = [marker.location for marker in markers.markers]
         assert locations == self.locations
 
     def test_all_pandas_df(self):
@@ -110,13 +110,13 @@ class MarkerLayer(unittest.TestCase):
             columns=["latitude", "longitude", "hover_text", "label"])
         options = self._add_default_options(
             hover_text=df["hover_text"], label=df["label"])
-        marker_options = _marker_layer_options(
+        markers = marker_layer(
             df[["latitude", "longitude"]], **options)
-        locations = [opts["location"] for opts in marker_options]
+        locations = [marker.location for marker in markers.markers]
         assert locations == self.locations
-        hover_texts = [opts["hover_text"] for opts in marker_options]
+        hover_texts = [marker.hover_text for marker in markers.markers]
         assert hover_texts == ["text1", "text2"]
-        labels = [opts["label"] for opts in marker_options]
+        labels = [marker.label for marker in markers.markers]
         assert labels == ["a", "b"]
 
 

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -12,7 +12,8 @@ from ..marker import (
     Markers,
     Symbol,
     _marker_layer_options,
-    _symbol_layer_options
+    _symbol_layer_options,
+    marker_layer
 )
 
 
@@ -31,6 +32,10 @@ class MarkerLayer(unittest.TestCase):
         new_options = self.kwargs.copy()
         new_options.update(options)
         return new_options
+
+    def test_locations(self):
+        markers = marker_layer(self.locations)
+        assert [marker.location for marker in markers.markers] == self.locations
 
     def test_hover_text_atomic(self):
         options = self._add_default_options(hover_text="test-text")

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -3,7 +3,6 @@ import unittest
 import pytest
 
 import numpy as np
-
 import traitlets
 
 from ..marker import (
@@ -352,6 +351,7 @@ class MarkersTest(unittest.TestCase):
     def test_bounds_markers(self):
         layer = Markers(markers=self.symbols)
         assert layer.has_bounds
+        assert layer.data_bounds
 
     def test_bounds_no_markers(self):
         layer = Markers(markers=[])

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -11,8 +11,8 @@ from ..marker import (
     Marker,
     Markers,
     Symbol,
-    _symbol_layer_options,
-    marker_layer
+    marker_layer,
+    symbol_layer
 )
 
 
@@ -142,89 +142,88 @@ class SymbolLayer(unittest.TestCase):
 
     def test_stroke_color_atomic_text(self):
         options = self._add_default_options(stroke_color="red")
-        symbol_options = _symbol_layer_options(
-            self.locations, **options)
-        for options in symbol_options:
-            assert options["stroke_color"] == "red"
+        symbols = symbol_layer(self.locations, **options)
+        for symbol in symbols.markers:
+            assert symbol.stroke_color == "red"
 
     def test_stroke_color_atomic_tuple(self):
         color = (10, 10, 10, 0.5)
         options = self._add_default_options(stroke_color=color)
-        symbol_options = _symbol_layer_options(self.locations, **options)
-        for options in symbol_options:
-            assert options["stroke_color"] == color
+        symbols = symbol_layer(self.locations, **options)
+        for symbol in symbols.markers:
+            assert symbol.stroke_color == 'rgba(10,10,10,0.5)'
 
     def test_stroke_color_list_text(self):
         options = self._add_default_options(stroke_color=["red", "green"])
-        symbol_options = _symbol_layer_options(self.locations, **options)
-        opts = [opts["stroke_color"] for opts in symbol_options]
-        assert tuple(opts) == ("red", "green")
+        symbols = symbol_layer(self.locations, **options)
+        colors = [symbol.stroke_color for symbol in symbols.markers]
+        assert colors == ["red", "green"]
 
     def test_stroke_color_list_tuples(self):
         c1 = (10, 10, 10, 0.5)
         c2 = (20, 20, 20, 0.5)
         options = self._add_default_options(stroke_color=[c1, c2])
-        symbol_options = _symbol_layer_options(self.locations, **options)
-        colors = [opts["stroke_color"] for opts in symbol_options]
-        assert tuple(colors) == (c1, c2)
+        symbols = symbol_layer(self.locations, **options)
+        colors = [symbol.stroke_color for symbol in symbols.markers]
+        assert colors == ['rgba(10,10,10,0.5)', 'rgba(20,20,20,0.5)']
 
     def test_infobox_default(self):
         options = self._add_default_options()
-        symbol_options = _symbol_layer_options(self.locations, **options)
-        for opts in symbol_options:
-            assert not opts["display_info_box"]
+        symbols = symbol_layer(self.locations, **options)
+        for symbol in symbols.markers:
+            assert not symbol.display_info_box
 
     def test_infobox_content_atomic(self):
         test_content = "<h3>test-html-infobox</h3>"
         options = self._add_default_options(
             info_box_content=test_content, display_info_box=True)
-        symbol_options = _symbol_layer_options(self.locations, **options)
-        for options in symbol_options:
-            assert options["info_box_content"] == test_content
-            assert options["display_info_box"]
+        symbols = symbol_layer(self.locations, **options)
+        for symbol in symbols.markers:
+            assert symbol.info_box_content == test_content
+            assert symbol.display_info_box
 
     def test_infobox_content_lists(self):
         test_content = ["1", "2"]
         options = self._add_default_options(
             info_box_content=test_content, display_info_box=True)
-        symbol_options = _symbol_layer_options(self.locations, **options)
-        content_options = [opts["info_box_content"] for opts in symbol_options]
-        assert tuple(content_options) == tuple(test_content)
+        symbols = symbol_layer(self.locations, **options)
+        content_options = [symbol.info_box_content for symbol in symbols.markers]
+        assert content_options == test_content
 
     def test_infobox_default_display_lists(self):
         test_content = ["1", None]
         options = self._add_default_options(info_box_content=test_content)
-        marker_options = _symbol_layer_options(self.locations, **options)
-        display_infos = [opts["display_info_box"] for opts in marker_options]
-        assert tuple(display_infos) == (True, False)
+        symbols = symbol_layer(self.locations, **options)
+        display_infos = [symbol.display_info_box for symbol in symbols.markers]
+        assert display_infos == [True, False]
 
     def test_opacity_default(self):
         options = self._add_default_options()
-        symbol_options = _symbol_layer_options(self.locations, **options)
-        for opts in symbol_options:
-            assert opts['fill_opacity'] == 1.0
-            assert opts['stroke_opacity'] == 1.0
+        symbols = symbol_layer(self.locations, **options)
+        for symbol in symbols.markers:
+            assert symbol.fill_opacity == 1.0
+            assert symbol.stroke_opacity == 1.0
 
     def test_opacity_single(self):
         options = self._add_default_options(
             fill_opacity=0.2, stroke_opacity=0.5)
-        symbol_options = _symbol_layer_options(self.locations, **options)
-        for opts in symbol_options:
-            assert opts['fill_opacity'] == 0.2
-            assert opts['stroke_opacity'] == 0.5
+        symbols = symbol_layer(self.locations, **options)
+        for symbol in symbols.markers:
+            assert symbol.fill_opacity == 0.2
+            assert symbol.stroke_opacity == 0.5
 
     def test_opacity_list(self):
         options = self._add_default_options(
             fill_opacity=[0.2, 0.4], stroke_opacity=[0.6, 0.7])
-        symbol_options = _symbol_layer_options(self.locations, **options)
+        symbols = symbol_layer(self.locations, **options)
         fill_opacity_options = [
-            opts["fill_opacity"] for opts in symbol_options
+            symbol.fill_opacity for symbol in symbols.markers
         ]
         stroke_opacity_options = [
-            opts["stroke_opacity"] for opts in symbol_options
+            symbol.stroke_opacity for symbol in symbols.markers
         ]
-        assert tuple(fill_opacity_options) == (0.2, 0.4)
-        assert tuple(stroke_opacity_options) == (0.6, 0.7)
+        assert fill_opacity_options == [0.2, 0.4]
+        assert stroke_opacity_options == [0.6, 0.7]
 
 
 class MarkerOptionsTests(unittest.TestCase):

--- a/gmaps/tests/test_marker.py
+++ b/gmaps/tests/test_marker.py
@@ -9,6 +9,7 @@ import traitlets
 from ..marker import (
     MarkerOptions,
     Marker,
+    Markers,
     Symbol,
     _marker_layer_options,
     _symbol_layer_options
@@ -321,3 +322,21 @@ class SymbolTest(unittest.TestCase):
             Symbol(self.location, stroke_opacity=1.2)
         with self.assertRaises(traitlets.TraitError):
             Symbol(self.location, stroke_opacity='not-a-float')
+
+
+class MarkersTest(unittest.TestCase):
+
+    def setUp(self):
+        self.locations = [(-5.0, 5.0), (10.0, 10.0)]
+        self.symbols = [
+            Symbol(location=location)
+            for location in self.locations
+        ]
+
+    def test_bounds_markers(self):
+        layer = Markers(markers=self.symbols)
+        assert layer.has_bounds
+
+    def test_bounds_no_markers(self):
+        layer = Markers(markers=[])
+        assert not layer.has_bounds


### PR DESCRIPTION
Prior to this PR, marker layers and symbol layers had to have at least one marker / symbol. This doesn't play well with dynamic applications, where it's reasonable to sometimes have no markers or symbols. See e.g. [the example application](https://jupyter-gmaps.readthedocs.io/en/latest/app_tutorial.html#updating-symbols-in-response-to-other-widgets) where the app should still work if both checkboxes are de-selected.

This PR also updates the tests to test against the marker and symbol layers directly.