### PR TITLE
Update Google Maps JS API version to 3.34

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -52,7 +52,7 @@
     "@jupyter-widgets/base": "^1.0.0",
     "@jupyter-widgets/controls": "^1.0.0",
     "flux": "^3.1.3",
-    "google-maps": "^3.2.1",
+    "google-maps": "^3.3.0",
     "jquery": "^3.2.1",
     "underscore": "^1.8.3",
     "backbone": "1.2.3"

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -33,6 +33,7 @@ function reloadGoogleMaps(configuration) {
     }
 
     GoogleMapsLoader.LIBRARIES = ['visualization'];
+    GoogleMapsLoader.VERSION = '3.34';
     if (
         configuration['api_key'] !== null &&
         configuration['api_key'] !== undefined


### PR DESCRIPTION
This PR updates the version of the Google Maps JavaScript API to 3.34. 

Google Maps Loader 3.3.0 currently defaults to 3.31, so we hard-code the version number.