### PR TITLE
Fix deprecation warnings on traitlets

### DIFF
--- a/gmaps/errors_box.py
+++ b/gmaps/errors_box.py
@@ -12,4 +12,4 @@ class ErrorsBox(GMapsWidgetMixin, widgets.DOMWidget):
     """
     _view_name = Unicode("ErrorsBoxView").tag(sync=True)
     _model_name = Unicode("ErrorsBoxModel").tag(sync=True)
-    errors = List(trait=Unicode).tag(sync=True)
+    errors = List(trait=Unicode()).tag(sync=True)

--- a/gmaps/figure.py
+++ b/gmaps/figure.py
@@ -34,9 +34,9 @@ class Figure(GMapsWidgetMixin, widgets.DOMWidget):
     """
     _view_name = Unicode("FigureView").tag(sync=True)
     _model_name = Unicode("FigureModel").tag(sync=True)
-    _toolbar = Instance(Toolbar, allow_none=True, default=None).tag(
+    _toolbar = Instance(Toolbar, allow_none=True).tag(
         sync=True, **widgets.widget_serialization)
-    _errors_box = Instance(ErrorsBox, allow_none=True, default=None).tag(
+    _errors_box = Instance(ErrorsBox, allow_none=True).tag(
         sync=True, **widgets.widget_serialization)
     _map = Instance(Map).tag(sync=True, **widgets.widget_serialization)
     map_type = MapType('ROADMAP')

--- a/gmaps/maps.py
+++ b/gmaps/maps.py
@@ -1,6 +1,6 @@
 
 import ipywidgets as widgets
-from traitlets import (Unicode, default, List, Tuple, Instance,
+from traitlets import (Unicode, default, List, Instance,
                        observe, Dict, HasTraits, Enum, Union)
 
 from .bounds import merge_longitude_bounds

--- a/gmaps/maps.py
+++ b/gmaps/maps.py
@@ -188,7 +188,7 @@ class Map(ConfigurationMixin, GMapsWidgetMixin, widgets.DOMWidget):
     """
     _view_name = Unicode('PlainmapView').tag(sync=True)
     _model_name = Unicode('PlainmapModel').tag(sync=True)
-    layers = Tuple(trait=Instance(widgets.Widget)).tag(
+    layers = List(trait=Instance(widgets.Widget)).tag(
         sync=True, **widgets.widget_serialization)
     data_bounds = List(DEFAULT_BOUNDS).tag(sync=True)
     initial_viewport = InitialViewport(default_value='DATA_BOUNDS').tag(

--- a/gmaps/tests/test_directions.py
+++ b/gmaps/tests/test_directions.py
@@ -38,12 +38,16 @@ class DirectionsLayer(unittest.TestCase):
         assert state['end'] == self.end
         assert state['waypoints'] == []
 
+    # Using the data traitlet is deprecated
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_set_data(self):
         layer = Directions(data=self.data_array)
         assert layer.start == self.start
         assert layer.end == self.end
         assert layer.waypoints == self.waypoints
 
+    # Using the start and end traitlets is deprecated
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_change_data(self):
         layer = Directions(start=(0.0, 0.0), end=(2.0, 2.0))
         layer.data = self.data_array

--- a/gmaps/tests/test_errors_box.py
+++ b/gmaps/tests/test_errors_box.py
@@ -1,0 +1,27 @@
+import unittest
+
+import traitlets
+
+from .. import errors_box
+
+
+class ErrorsBox(unittest.TestCase):
+
+    def test_no_errors(self):
+        box = errors_box.ErrorsBox()
+        assert box.get_state()["errors"] == []
+
+    def test_with_errors(self):
+        errors = ["first", "second"]
+        box = errors_box.ErrorsBox(errors=errors)
+        assert box.get_state()["errors"] == errors
+
+    def test_change_errors(self):
+        box = errors_box.ErrorsBox(errors=["first", "second"])
+        new_errors = ["third"]
+        box.errors = new_errors
+        assert box.get_state()["errors"] == new_errors
+
+    def test_refuse_non_unicode(self):
+        with self.assertRaises(traitlets.TraitError):
+            errors_box.ErrorsBox(errors=[42])

--- a/gmaps/tests/test_figure.py
+++ b/gmaps/tests/test_figure.py
@@ -1,10 +1,37 @@
 import unittest
 
+import traitlets
+
 from ..figure import figure, Figure, FigureLayout
 from ..maps import Map
+from ..toolbar import Toolbar
+from ..errors_box import ErrorsBox
 
 
 class TestFigure(unittest.TestCase):
+
+    def test_defaults(self):
+        fig = Figure(_map=Map())
+        assert fig._toolbar is None
+        assert fig._errors_box is None
+
+    def test_with_toolbar(self):
+        toolbar = Toolbar()
+        fig = Figure(_map=Map(), _toolbar=toolbar)
+        assert fig._toolbar == toolbar
+
+    def test_validate_toolbar(self):
+        with self.assertRaises(traitlets.TraitError):
+            Figure(_map=Map(), _toolbar=42)
+
+    def test_with_errors_box(self):
+        errors_box = ErrorsBox()
+        fig = Figure(_map=Map(), _errors_box=errors_box)
+        assert fig._errors_box == errors_box
+
+    def test_validate_errors_box(self):
+        with self.assertRaises(traitlets.TraitError):
+            Figure(_map=Map(), _errors_box=42)
 
     def test_proxy_map_type(self):
         fig = Figure(_map=Map(), map_type='HYBRID')

--- a/gmaps/tests/test_maps.py
+++ b/gmaps/tests/test_maps.py
@@ -45,6 +45,11 @@ class Map(unittest.TestCase):
             'IPY_MODEL_' + test_layer.model_id,
         ]
 
+    def test_invalid_layer(self):
+        m = maps.Map()
+        with self.assertRaises(traitlets.TraitError):
+            m.layers = [52]
+
 
 class InitialViewport(unittest.TestCase):
 

--- a/gmaps/tests/test_maps.py
+++ b/gmaps/tests/test_maps.py
@@ -35,6 +35,16 @@ class Map(unittest.TestCase):
         assert state['layers'] == ['IPY_MODEL_' + test_layer.model_id]
         assert state['mouse_handling'] == 'NONE'
 
+    def test_change_layer(self):
+        test_layer = heatmap_layer([(1.0, 2.0), (3.0, 4.0)])
+        m = maps.Map()
+        assert m.get_state()['layers'] == []
+        m.layers = [test_layer, test_layer]
+        assert m.get_state()['layers'] == [
+            'IPY_MODEL_' + test_layer.model_id,
+            'IPY_MODEL_' + test_layer.model_id,
+        ]
+
 
 class InitialViewport(unittest.TestCase):
 


### PR DESCRIPTION
Prior to this PR, running the tests raised some warnings. This fixes them, and introduces additional unit tests for the changes.