### PR TITLE
Update for JupyterLab 1.0.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,21 @@ installation. You can also trigger this directly on the command line with::
 
     $ jupyter lab build
 
+Support for JupyterLab pre 1.0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To install `jupyter-gmaps` with versions of JupyterLab pre 1.0, you will need to pin the version of `jupyterlab-manager` and of `jupyter-gmaps`. Find the version of the `jupyterlab-manager` that you need from `this compatibility table <https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager>`_. For instance, for JupyterLab 0.35.x::
+
+    $ jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.38
+
+Then, install a pinned version of `jupyter-gmaps`::
+
+    $ pip install gmaps==0.8.4
+
+You will then need to rebuild JupyterLab with::
+
+    $ jupyter lab build
+
 
 Google API keys
 ---------------

--- a/gmaps/_version.py
+++ b/gmaps/_version.py
@@ -2,7 +2,7 @@
 # This file is generated programatically.
 
 # Version of the Python package
-__version__ = '0.8.5-dev'
+__version__ = '0.9.0-rc1'
 
 # Version of the JS client. This must match the version field in package.json.
-CLIENT_VERSION = '0.8.5-dev'
+CLIENT_VERSION = '0.9.0-rc1'

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-gmaps",
-  "version": "0.8.5-dev",
+  "version": "0.9.0-rc1",
   "description": "Google maps plugin for Jupyter notebooks",
   "author": "Pascal Bugnion",
   "main": "src/index.js",

--- a/js/package.json
+++ b/js/package.json
@@ -50,8 +50,8 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.0.0",
-    "@jupyter-widgets/controls": "^1.0.0",
+    "@jupyter-widgets/base": "^2.0.0",
+    "@jupyter-widgets/controls": "^1.5.0",
     "flux": "^3.1.3",
     "google-maps": "^3.3.0",
     "jquery": "^3.2.1",


### PR DESCRIPTION
This fixes the dependencies on the Jupyter widget registry.

Left to do:
- [x] prerelease and test
- [x] update readme
- [x] test installation instructions for JLab < 1.0