### PR TITLE
Add dynamic update capability for viewport based on data bounds

### DIFF
--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -127,6 +127,13 @@ export class PlainmapView extends ConfigurationMixin(widgets.DOMWidgetView) {
             this.setMapOptions({mapTypeId});
         });
 
+        this.model.on('change:data_bounds', () => {
+            const {type} = this.model.get('initial_viewport');
+            if (type === DATA_BOUNDS) {
+                this.setViewportFromBounds(this.model.get('data_bounds'));
+            }
+        });
+
         this.model.on('change:tilt', () => {
             this.setMapOptions({tilt: this.model.get('tilt')});
         });


### PR DESCRIPTION
Allows dynamically updating the viewport based on changes in the data bounds of the layers, e.g.:

```
import gmaps

class MapContainer(object):
    def __init__(self):
        self._fig = gmaps.figure()
        self._marker_layer = gmaps.marker_layer(locations=[])
        self._fig.add_layer(self._marker_layer)
        display(self._fig)
        
    def update(self, coordinates_list):
        self._marker_layer.markers = [gmaps.Marker(location=coordinates) 
                                      for coordinates in coordinates_list]
        self._fig._map._calc_bounds({'new': self._fig._map.layers})
        
        
container = MapContainer()
```

```
london_coordinates = (51.507942, -0.127566)
berlin_coordinates = (52.518880, 13.408935)
new_york_coordinates = (40.708081, -74.005807)
washington_coordinates = (38.910675, -77.035177)
```

```
container.update([london_coordinates, berlin_coordinates])
```
![map_london_berlin](https://user-images.githubusercontent.com/40323648/73690870-9202fd00-46d1-11ea-8d8a-78327de5e8f4.png)


```
container.update([new_york_coordinates, washington_coordinates])
```
![map_new_york_washington](https://user-images.githubusercontent.com/40323648/73690878-96c7b100-46d1-11ea-9da1-1a527be2574b.png)
