### PR TITLE
Import collections.abc if missing from base class

### DIFF
--- a/gmaps/options.py
+++ b/gmaps/options.py
@@ -1,5 +1,8 @@
-
-import collections
+try:
+    import collections
+    collections.Iterable
+except Exception:
+    import collections.abc as collections
 
 from six import string_types
 


### PR DESCRIPTION
This PR addresses https://github.com/pbugnion/gmaps/issues/352.

Try to access the abstract base classes on the collections object, and if we cannot they need to be accessed from collections.abc.